### PR TITLE
fix: 明确设置touchstart/touchmove事件的passive配置项

### DIFF
--- a/src/utils/moveable.ts
+++ b/src/utils/moveable.ts
@@ -64,10 +64,10 @@ export function moveable(el: HTMLElement) {
     document.addEventListener('mousemove', move, false);
     document.addEventListener('mouseup', end, false);
 
-    document.addEventListener('touchmove', move, false);
+    document.addEventListener('touchmove', move, { capture: false, passive: false });
     document.addEventListener('touchend', end, false);
   }
 
   el.addEventListener('mousedown', start, false);
-  el.addEventListener('touchstart', start, false);
+  el.addEventListener('touchstart', start, { capture: false, passive: false });
 }


### PR DESCRIPTION
现有的`touchstart`和`touchmove`事件在绑定时第三个参数为`false`，根据 https://chromestatus.com/feature/5093566007214080 处的说明，某些高版本浏览器`passive`选项默认为`true`，也就会导致事件处理器内部在调用`e.preventDefault()`时报如下错误：

![image](https://github.com/HuolalaTech/page-spy/assets/7316006/26901794-1855-4749-9b92-96b5be42657a)

因此需要将这两类事件明确配置为`passive:false`