### PR TITLE
fix: use ArrayBuffer.isView instead of constructor

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -104,19 +104,7 @@ type TypedArray =
   | BigInt64Array
   | BigUint64Array;
 export function isTypedArray(value: unknown): value is TypedArray {
-  return [
-    Int8Array,
-    Uint8Array,
-    Uint8ClampedArray,
-    Int16Array,
-    Uint16Array,
-    Int32Array,
-    Uint32Array,
-    Float32Array,
-    Float64Array,
-    BigInt64Array,
-    BigUint64Array,
-  ].includes(Object.getPrototypeOf(value).constructor);
+  return ArrayBuffer.isView(value);
 }
 
 interface PrimitiveResult {


### PR DESCRIPTION
TypedArray cannot be polyfilled and throw error like 'BigInt64Array is not defined'