### PR TITLE
Repair: 在资源路径不存在下error为undefined的情况

### DIFF
--- a/src/plugins/error.ts
+++ b/src/plugins/error.ts
@@ -40,13 +40,9 @@ export default class ErrorPlugin implements PageSpyPlugin {
         ErrorPlugin.sendMessage(stack || message, errorDetail);
       } else {
         // When the error does not exist, use default information
-        const defaultMessage = 'An unknown error occurred';
-        const defaultStack = 'No stack trace available';
-        ErrorPlugin.sendMessage(defaultMessage, {
-          name: '',
-          message: defaultMessage,
-          stack: defaultStack,
-        });
+        const defaultMessage =
+          '[PageSpy] An unknown error occurred and no stack trace available';
+        ErrorPlugin.sendMessage(defaultMessage, null);
       }
     };
     window.addEventListener('error', errorHandler);

--- a/src/plugins/error.ts
+++ b/src/plugins/error.ts
@@ -34,9 +34,20 @@ export default class ErrorPlugin implements PageSpyPlugin {
 
   private onUncaughtError() {
     const errorHandler = (e: ErrorEvent) => {
-      const { message, stack } = e.error;
-      const errorDetail = formatErrorObj(e.error);
-      ErrorPlugin.sendMessage(stack || message, errorDetail);
+      if (e.error) {
+        const { message, stack } = e.error;
+        const errorDetail = formatErrorObj(e.error);
+        ErrorPlugin.sendMessage(stack || message, errorDetail);
+      } else {
+        // When the error does not exist, use default information
+        const defaultMessage = 'An unknown error occurred';
+        const defaultStack = 'No stack trace available';
+        ErrorPlugin.sendMessage(defaultMessage, {
+          name: '',
+          message: defaultMessage,
+          stack: defaultStack,
+        });
+      }
     };
     window.addEventListener('error', errorHandler);
   }

--- a/tests/plugins/error.test.ts
+++ b/tests/plugins/error.test.ts
@@ -21,10 +21,9 @@ describe('Error plugin', () => {
     window.dispatchEvent(new Event('error'));
 
     expect(errorOccupied).toHaveBeenCalledTimes(3);
-    expect(errorOccupied).toHaveBeenCalledWith('An unknown error occurred', {
-      name: '',
-      message: 'An unknown error occurred',
-      stack: 'No stack trace available',
-    });
+    expect(errorOccupied).toHaveBeenCalledWith(
+      '[PageSpy] An unknown error occurred and no stack trace available',
+      null,
+    );
   });
 });

--- a/tests/plugins/error.test.ts
+++ b/tests/plugins/error.test.ts
@@ -16,4 +16,15 @@ describe('Error plugin', () => {
     window.dispatchEvent(new Event('unhandledrejection'));
     expect(errorOccupied).toHaveBeenCalledTimes(3);
   });
+
+  it('Should handle error event without error object', () => {
+    window.dispatchEvent(new Event('error'));
+
+    expect(errorOccupied).toHaveBeenCalledTimes(3);
+    expect(errorOccupied).toHaveBeenCalledWith('An unknown error occurred', {
+      name: '',
+      message: 'An unknown error occurred',
+      stack: 'No stack trace available',
+    });
+  });
 });


### PR DESCRIPTION
![ff469fcf-7a8c-442b-ab27-aae4a83b6b74](https://github.com/HuolalaTech/page-spy/assets/82022476/5577da6e-7094-4355-b449-274cb9319d5f)
<img width="908" alt="image" src="https://github.com/HuolalaTech/page-spy/assets/82022476/dbba5600-5e4a-4814-a789-0dc1e2edf7a5">

在本地接入的项目中引入一个不存在的资源路径地址后抛出错误，此错误应在内部消化掉而不抛出给客户端

![2f7e6f04-ca55-484d-97d3-065af5312182](https://github.com/HuolalaTech/page-spy/assets/82022476/e85ea17b-62b9-4b65-bb89-fc0245ab5f14)

修复后的测试用例结果