### PR TITLE
[page-spy-browser] feat: add 'offline' constructor option

### DIFF
--- a/packages/page-spy-alipay/types/index.d.ts
+++ b/packages/page-spy-alipay/types/index.d.ts
@@ -7,7 +7,6 @@ export { InitConfig };
 interface PageSpyConstructor {
   new (config: InitConfig): PageSpyBase;
   instance: PageSpyBase | null;
-  abort(): void;
 }
 
 declare const PageSpy: PageSpyConstructor;

--- a/packages/page-spy-browser/README.md
+++ b/packages/page-spy-browser/README.md
@@ -74,9 +74,10 @@ interface InitConfig {
   // You can disable some plugins as needed.
   disabledPlugins?: (InternalPlugins | string)[];
 
-  // After adding support for offline replay in PageSpy, the client-integrated SDK can work without
-  // establishing a connection with the debugger. Default value is false, when users set it to other values,
-  // it enters "offline mode", where PageSpy will not create rooms or establish WebSocket connections.
+  // After adding support for offline replay in PageSpy@1.7.4, the client-integrated SDK can work without
+  // establishing a connection with the debugger.
+  // Default value is false, when users set it to other values will enters "offline mode", where PageSpy
+  // will not create rooms or establish WebSocket connections.
   offline?: boolean;
 }
 

--- a/packages/page-spy-browser/README.md
+++ b/packages/page-spy-browser/README.md
@@ -73,6 +73,11 @@ interface InitConfig {
   // All internal plugins are carried with PageSpy by default out of the box.
   // You can disable some plugins as needed.
   disabledPlugins?: (InternalPlugins | string)[];
+
+  // After adding support for offline replay in PageSpy, the client-integrated SDK can work without
+  // establishing a connection with the debugger. Default value is false, when users set it to other values,
+  // it enters "offline mode", where PageSpy will not create rooms or establish WebSocket connections.
+  offline?: boolean;
 }
 
 type InternalPlugins =

--- a/packages/page-spy-browser/README_ZH.md
+++ b/packages/page-spy-browser/README_ZH.md
@@ -69,6 +69,11 @@ interface InitConfig {
 
   // PageSpy 所有内置插件默认开启，可以按需禁用指定插件。
   disabledPlugins?: (InternalPlugins | string)[];
+
+  // 在 PageSpy 支持离线回放功能后，客户端集成的 SDK 可以不用和调试端建立连接，
+  // 只需通过 DataHarborPlugin 收集数据、导出离线日志即可。
+  // 默认值 false。用户设置为其他值时，会进入 "离线模式"，具体表现为 PageSpy 不会创建房间、建立 WebSocket 连接。
+  offline?: boolean;
 }
 
 type InternalPlugins =

--- a/packages/page-spy-browser/README_ZH.md
+++ b/packages/page-spy-browser/README_ZH.md
@@ -70,7 +70,7 @@ interface InitConfig {
   // PageSpy 所有内置插件默认开启，可以按需禁用指定插件。
   disabledPlugins?: (InternalPlugins | string)[];
 
-  // 在 PageSpy 支持离线回放功能后，客户端集成的 SDK 可以不用和调试端建立连接，
+  // 在 PageSpy@1.7.4 支持离线回放功能后，客户端集成的 SDK 可以不用和调试端建立连接，
   // 只需通过 DataHarborPlugin 收集数据、导出离线日志即可。
   // 默认值 false。用户设置为其他值时，会进入 "离线模式"，具体表现为 PageSpy 不会创建房间、建立 WebSocket 连接。
   offline?: boolean;

--- a/packages/page-spy-browser/src/api/index.ts
+++ b/packages/page-spy-browser/src/api/index.ts
@@ -1,5 +1,6 @@
 import { psLog } from 'base/src';
 import { Config } from 'page-spy-browser/src/config';
+import { InitConfig } from 'page-spy-browser/types';
 
 interface TResponse<T> {
   code: string;
@@ -25,15 +26,15 @@ const joinQuery = (args: Record<string, unknown>) => {
 };
 
 export default class Request {
-  constructor(public config: Config) {
+  constructor(public config: Required<InitConfig>) {
     /* c8 ignore next 3 */
-    if (!config.get().api) {
+    if (!config.api) {
       throw Error('The api base url cannot be empty');
     }
   }
 
   get base() {
-    return this.config.get().api;
+    return this.config.api;
   }
 
   parseSchemeWithScript() {
@@ -51,7 +52,7 @@ export default class Request {
   }
 
   getScheme() {
-    const { enableSSL } = this.config.get();
+    const { enableSSL } = this.config;
     if (typeof enableSSL !== 'boolean') {
       return this.parseSchemeWithScript();
     }
@@ -59,12 +60,12 @@ export default class Request {
   }
 
   createRoom(): Promise<TResponse<TCreateRoom>> {
-    const config = this.config.get();
+    const { project, title } = this.config;
     const scheme = this.getScheme();
     const query = joinQuery({
       name: navigator.userAgent,
-      group: config.project,
-      title: config.title,
+      group: project,
+      title,
     });
     return fetch(`${scheme[0]}${this.base}/api/v1/room/create?${query}`, {
       method: 'POST',

--- a/packages/page-spy-browser/src/config.ts
+++ b/packages/page-spy-browser/src/config.ts
@@ -14,9 +14,10 @@ export class Config extends ConfigBase<InitConfig> {
       clientOrigin: '',
       project: 'default',
       autoRender: true,
-      title: '',
+      title: '--',
       enableSSL: null,
       disabledPlugins: [],
+      offline: false,
     };
 
     if (!Config.scriptLink) {

--- a/packages/page-spy-browser/tests/api/index.test.ts
+++ b/packages/page-spy-browser/tests/api/index.test.ts
@@ -7,7 +7,7 @@ describe('Web API utils fn', () => {
     config.mergeConfig({
       api: 'init-api',
     });
-    const request = new Request(config);
+    const request = new Request(config.get());
     const originLink = Config.scriptLink;
 
     // <script src="https://exp.com/page-spy/index.min.js"></script>

--- a/packages/page-spy-browser/types/index.d.ts
+++ b/packages/page-spy-browser/types/index.d.ts
@@ -25,6 +25,12 @@ export interface InitConfig extends InitConfigBase {
    * You can disable some plugins as needed.
    */
   disabledPlugins?: (InternalPlugins | string)[];
+  /**
+   * Indicate whether enable offline mode. Once enabled, PageSpy will not
+   * make network requests and send data by server. Collected data can be
+   * exported with "DataHarborPlugin" and then replayed in the debugger.
+   */
+  offline?: boolean;
 }
 
 interface PageSpyBrowser extends PageSpyBase {

--- a/packages/page-spy-browser/types/index.d.ts
+++ b/packages/page-spy-browser/types/index.d.ts
@@ -36,13 +36,12 @@ export interface InitConfig extends InitConfigBase {
 interface PageSpyBrowser extends PageSpyBase {
   root: HTMLElement | null;
   config: Required<InitConfig> | null;
+  render(): void;
 }
 
 interface PageSpyConstructor {
   new (config?: InitConfig): PageSpyBrowser;
   instance: PageSpyBrowser | null;
-  render(): void;
-  abort(): void;
 }
 
 declare const PageSpy: PageSpyConstructor;

--- a/packages/page-spy-types/lib/index.d.ts
+++ b/packages/page-spy-types/lib/index.d.ts
@@ -38,6 +38,7 @@ export interface PageSpyBase {
   name: string;
   address: string;
   roomUrl: string;
+  abort(): void;
 }
 
 interface OnInitParams<T extends InitConfigBase = InitConfigBase> {

--- a/packages/page-spy-uniapp/types/index.d.ts
+++ b/packages/page-spy-uniapp/types/index.d.ts
@@ -3,7 +3,6 @@ import { PageSpyBase, SpyMP } from '@huolala-tech/page-spy-types';
 interface PageSpyConstructor {
   new (config: SpyMP.MPInitConfig): PageSpyBase;
   instance: PageSpyBase | null;
-  abort(): void;
 }
 
 declare const PageSpy: PageSpyConstructor;

--- a/packages/page-spy-wechat/types/index.d.ts
+++ b/packages/page-spy-wechat/types/index.d.ts
@@ -7,7 +7,6 @@ export { InitConfig };
 interface PageSpyConstructor {
   new (config: InitConfig): PageSpyBase;
   instance: PageSpyBase | null;
-  abort(): void;
 }
 
 declare const PageSpy: PageSpyConstructor;


### PR DESCRIPTION
After adding support for offline replay in PageSpy, the client-integrated SDK can work without establishing a connection with the debugger. The SDK collects data and export offline logs through the `DataHarborPlugin`. Therefore, the main changes included in this submission are as follows:
( PageSpy 支持离线回放功能后，客户端集成的 SDK 可以不用和调试端建立连接，只需通过 DataHarborPlugin 收集数据、导出离线日志即可。所以此次提交的改动主要包含：)

-  `page-spy-browser`: add `offline: boolean` parameter with a default value of `false`. When users set it to other values, it enters "offline mode," where PageSpy will not create rooms or establish WebSocket connections.
  ( `page-spy-browser`：实例化新增 `offline: boolean` 参数，默认值 `false`。用户设置为其他值时，会进入 "离线模式"，具体表现为 PageSpy 不会创建房间、建立 WebSocket 连接。)

```js
window.$pageSpy = new PageSpy({
  ...,
  offline: true
})
```
