### PR TITLE
[page-spy-plugin-data-harbor] refactor

### DIFF
--- a/packages/page-spy-plugin-data-harbor/src/harbor/index.ts
+++ b/packages/page-spy-plugin-data-harbor/src/harbor/index.ts
@@ -1,39 +1,83 @@
-import { Container } from './base';
-import IDBContainer from './idb-container';
-import MemoryContainer from './memory-container';
-
-const CONTAINER_SAVE_AS = [
-  {
-    saveAs: 'memory',
-    container: MemoryContainer,
-  },
-  {
-    saveAs: 'indexedDB',
-    container: IDBContainer,
-  },
-] as const;
-
-export type SaveAs = (typeof CONTAINER_SAVE_AS)[number]['saveAs'];
+import { isBrowser, isNumber } from 'base/src';
 
 interface HarborConfig {
-  saveAs: SaveAs;
+  maximum?: number;
 }
 
-export class Harbor {
-  container: Container;
+let currentContainerSize = 0;
 
-  constructor(config: HarborConfig) {
-    const targetContainer = CONTAINER_SAVE_AS.find(
-      (i) => i.saveAs === config.saveAs,
-    );
-    if (!targetContainer) {
-      throw new Error(
-        `[DataHarborPlugin] The "saveAs" you passed is not exist, valid value: ${CONTAINER_SAVE_AS.map(
-          (i) => i.saveAs,
-        )}`,
-      );
+export class Harbor {
+  // Object URL list
+  stock: string[] = [];
+
+  container: any[] = [];
+
+  // Specify the maximum bytes of single harbor's container.
+  // Default 10MB.
+  private maximum = 10 * 1024 * 1024;
+
+  constructor(config?: HarborConfig) {
+    if (config && isNumber(config.maximum) && config.maximum >= 0) {
+      this.maximum = config.maximum;
     }
-    // eslint-disable-next-line new-cap
-    this.container = new targetContainer.container();
+    if (isBrowser()) {
+      window.addEventListener('beforeunload', () => {
+        this.stock.forEach((i) => {
+          URL.revokeObjectURL(i);
+        });
+      });
+    }
+  }
+
+  public save(data: any) {
+    try {
+      const { size } = new Blob([JSON.stringify(data)], {
+        type: 'application/json',
+      });
+      const newSize = currentContainerSize + size;
+      if (newSize >= this.maximum) {
+        const data2objectUrl = URL.createObjectURL(
+          new Blob([JSON.stringify(this.container)], {
+            type: 'application/json',
+          }),
+        );
+        this.stock.push(data2objectUrl);
+        this.container = [data];
+        currentContainerSize = 0;
+      } else {
+        this.container.push(data);
+        currentContainerSize = newSize;
+      }
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  async getHarborData() {
+    const stockData = await Promise.all(
+      this.stock.map(async (i) => {
+        try {
+          const res = await fetch(i);
+          if (!res.ok) return null;
+          const data = JSON.parse(await res.text());
+          return data;
+        } catch (e) {
+          return null;
+        }
+      }),
+    );
+    const validStockData = stockData.filter(Boolean);
+    const combinedData = validStockData.reduce(
+      (acc, cur) => acc.concat(cur),
+      [],
+    );
+    return combinedData.concat(this.container);
+  }
+
+  clear() {
+    this.stock.forEach((i) => URL.revokeObjectURL(i));
+    this.stock = [];
+    this.container = [];
   }
 }


### PR DESCRIPTION

Before, DataHarborPlugin would store collected data in indexedDB by default (specified by the saveAs parameter to store in memory or db), but there were performance issues in actual use. This was due to occasional unresponsiveness of indexedDB caused by high-frequency data operations or processing large volumes of data transactions. As a result, there was a possibility of incomplete data when exporting logs during playback.

之前，`DataHarborPlugin` 默认将收集的数据存在 `indexedDB` 中（通过 `saveAs` 参数指定存储在内存或 db 中），但是实际使用过程中存在性能问题，因为高频的数据操作或者处理大体积数据的事务等原因会导致偶发 `indexedDB` 失去响应。最终导致的结果是导出的日志在回放时，数据存在不完整的可能性。

To improve reliability, this commit refactors the "storage" module inside DataHarborPlugin. Now, all data is by default stored in client-side memory. When the accumulated data volume reaches 10MB (default value, specified by maximum), the data is managed through URL.createObjectUrl().

为了提升可靠性，本次提交重构了 `DataHarborPlugin` 内部的 "存储"模块。现在所有数据都默认放到客户端内存中，当收集的数据体积累计达到 10MB 时（默认值，可通过 `maximum` 指定），将数据通过 `URL.createObjectUrl()` 管理。

```js
...

PageSpy.registerPlugin(new DataHarborPlugin({
  maximum: 10 * 1024 * 1024 // Default value 10 MB
}))
```