### PR TITLE
a simpler implementation of socket interface for different platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.1.0",
     "eslint-plugin-import": "^2.29.1",
-    "events": "^3.3.0",
     "express": "^4.18.2",
     "fake-indexeddb": "^5.0.2",
     "jest": "^29.7.0",

--- a/packages/base/src/event-emitter.ts
+++ b/packages/base/src/event-emitter.ts
@@ -1,0 +1,43 @@
+// There are many where use event emitter, but the platform may not
+// natively support it, so we made our own.
+export class EventEmitter<E extends string, C extends Function> {
+  private events: Map<E, C[]> = new Map();
+
+  on(eventName: E, callback: C) {
+    let list = this.events.get(eventName);
+    if (!list) {
+      list = [];
+      this.events.set(eventName, list);
+    }
+    if (list.indexOf(callback) < 0) {
+      list.push(callback);
+    }
+  }
+
+  off(eventName: E, callback: C) {
+    if (this.events.has(eventName)) {
+      const list = this.events.get(eventName);
+      const i = list!.indexOf(callback);
+      if (i >= 0) {
+        list?.splice(i, 1);
+      }
+    }
+  }
+
+  emit(eventName: E, ...args: any[]) {
+    const list = this.events.get(eventName);
+    if (list) {
+      list.forEach((cb) => {
+        cb(...args);
+      });
+    }
+  }
+
+  clearListeners(eventName: E) {
+    this.events.delete(eventName);
+  }
+
+  clearAllListeners() {
+    this.events.clear();
+  }
+}

--- a/packages/base/src/event-emitter.ts
+++ b/packages/base/src/event-emitter.ts
@@ -3,7 +3,7 @@
 export class EventEmitter<E extends string, C extends Function> {
   private events: Map<E, C[]> = new Map();
 
-  on(eventName: E, callback: C) {
+  addEventListener(eventName: E, callback: C) {
     let list = this.events.get(eventName);
     if (!list) {
       list = [];
@@ -14,7 +14,7 @@ export class EventEmitter<E extends string, C extends Function> {
     }
   }
 
-  off(eventName: E, callback: C) {
+  removeEventListener(eventName: E, callback: C) {
     if (this.events.has(eventName)) {
       const list = this.events.get(eventName);
       const i = list!.indexOf(callback);

--- a/packages/base/tests/network/base.test.ts
+++ b/packages/base/tests/network/base.test.ts
@@ -1,12 +1,12 @@
-import {
-  SocketState,
-  SocketStoreBase,
-  SocketWrapper,
-} from 'base/src/socket-base';
+import { SocketState, SocketStoreBase, ISocket } from 'base/src/socket-base';
 import NetworkProxyBase from 'base/src/network/base';
 import RequestItem from 'base/src/request-item';
 
-class PlatformSocketWrapper extends SocketWrapper {
+class PlatformSocketImpl implements ISocket {
+  readyState: SocketState = 0;
+  constructor(url: string) {
+    this.init(url);
+  }
   init(url: string): void {
     throw new Error('Method not implemented.');
   }
@@ -22,10 +22,19 @@ class PlatformSocketWrapper extends SocketWrapper {
   getState(): SocketState {
     throw new Error('Method not implemented.');
   }
+  addEventListener(
+    event: keyof WebSocketEventMap,
+    callback: (data?: any) => void,
+  ): void {}
+  removeEventListener(
+    event: keyof WebSocketEventMap,
+    callback: (data?: any) => void,
+  ): void {}
 }
-
 class PlatformSocket extends SocketStoreBase {
-  protected socketWrapper: SocketWrapper = new PlatformSocketWrapper();
+  createSocket(url: string): ISocket {
+    return new PlatformSocketImpl(url);
+  }
   onOffline(): void {
     throw new Error('Method not implemented.');
   }

--- a/packages/mp-base/src/helpers/socket.ts
+++ b/packages/mp-base/src/helpers/socket.ts
@@ -80,20 +80,6 @@ export class MPSocketImpl
   getState(): SocketState {
     return this._state;
   }
-
-  addEventListener(
-    event: keyof WebSocketEventMap,
-    callback: (data?: any) => void,
-  ): void {
-    this.on(event, callback);
-  }
-
-  removeEventListener(
-    event: keyof WebSocketEventMap,
-    callback: (data?: any) => void,
-  ): void {
-    this.off(event, callback);
-  }
 }
 
 export class MPSocketStore extends SocketStoreBase {

--- a/packages/mp-base/src/index.ts
+++ b/packages/mp-base/src/index.ts
@@ -15,7 +15,7 @@ import NetworkPlugin from './plugins/network';
 import SystemPlugin from './plugins/system';
 import StoragePlugin from './plugins/storage';
 
-import socketStore, { MPSocketWrapper } from './helpers/socket';
+import socketStore, { MPSocketImpl } from './helpers/socket';
 import Request from './api';
 
 // import './index.less';
@@ -100,7 +100,7 @@ class PageSpy {
     const config = this.config.mergeConfig(init);
 
     if (config.singletonSocket) {
-      MPSocketWrapper.isSingleSocket = true;
+      MPSocketImpl.isSingleSocket = true;
     }
 
     const mp = getMPSDK();
@@ -174,7 +174,7 @@ class PageSpy {
       mp.onAppShow(() => {
         // Mini programe can not detect ws disconnect (before we add heart beat ping pong).
         // So we need to refresh the connection.
-        const state = socketStore.getSocket().getState();
+        const state = socketStore.getSocket()?.readyState;
         if (state === SocketState.CLOSED || state === SocketState.CLOSING) {
           this.useOldConnection();
         }

--- a/packages/mp-base/tests/mock/mp.ts
+++ b/packages/mp-base/tests/mock/mp.ts
@@ -1,6 +1,6 @@
 import { SocketState } from 'base/src/socket-base';
 import { mockRequest } from './request';
-import EventEmitter from 'events';
+import { EventEmitter } from 'base/src/event-emitter';
 type CBType = (event?: any) => any;
 
 export class MockSocket {
@@ -9,16 +9,16 @@ export class MockSocket {
   send(params: { data: string | Buffer }) {}
   onOpen(handler: (res: any) => void) {
     this.status = SocketState.OPEN;
-    this.ee.addListener('open', handler);
+    this.ee.addEventListener('open', handler);
   }
   onClose(handler: (res: any) => void) {
-    this.ee.addListener('close', handler);
+    this.ee.addEventListener('close', handler);
   }
   onError(handler: (msg: string) => void) {
-    this.ee.addListener('error', handler);
+    this.ee.addEventListener('error', handler);
   }
   onMessage(handler: (data: string | Buffer) => void) {
-    this.ee.addListener('message', handler);
+    this.ee.addEventListener('message', handler);
   }
   close() {
     if (this.status !== SocketState.CLOSED) {

--- a/packages/page-spy-browser/src/helpers/socket.ts
+++ b/packages/page-spy-browser/src/helpers/socket.ts
@@ -2,55 +2,18 @@ import { getRandomId, stringifyData } from 'base/src';
 import atom from 'base/src/atom';
 import { ROOM_SESSION_KEY } from 'base/src/constants';
 import { makeMessage } from 'base/src/message';
-import {
-  SocketStoreBase,
-  SocketState,
-  SocketWrapper,
-  WebSocketEvents,
-} from 'base/src/socket-base';
+import { ISocket, SocketStoreBase } from 'base/src/socket-base';
 import { SpyBase } from 'packages/page-spy-types';
-
-export class WebSocketWrapper extends SocketWrapper {
-  private socketInstance: WebSocket | null = null;
-
-  init(url: string) {
-    this.socketInstance = new WebSocket(url);
-    const eventNames: WebSocketEvents[] = ['open', 'close', 'error', 'message'];
-    eventNames.forEach((eventName) => {
-      this.socketInstance!.addEventListener(eventName, (data) => {
-        this.events[eventName].forEach((cb) => {
-          cb(data);
-        });
-      });
-    });
-  }
-
-  send(data: string) {
-    this.socketInstance?.send(stringifyData(data));
-  }
-
-  close() {
-    this.socketInstance?.close();
-  }
-
-  getState(): SocketState {
-    return this.socketInstance?.readyState as SocketState;
-  }
-}
-
 export class WebSocketStore extends SocketStoreBase {
-  // websocket instance
-  protected socketWrapper: WebSocketWrapper = new WebSocketWrapper();
-
-  public getSocket() {
-    return this.socketWrapper;
-  }
-
   // disable lint: this is an abstract method of parent class, so it cannot be static
   // eslint-disable-next-line class-methods-use-this
   onOffline(): void {
     window.dispatchEvent(new CustomEvent('sdk-inactive'));
     sessionStorage.setItem(ROOM_SESSION_KEY, JSON.stringify({ usable: false }));
+  }
+
+  createSocket(url: string): ISocket {
+    return new WebSocket(url);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-useless-constructor

--- a/packages/page-spy-browser/tests/init.test.ts
+++ b/packages/page-spy-browser/tests/init.test.ts
@@ -192,7 +192,7 @@ describe('new PageSpy([config])', () => {
       JSON.stringify({
         name: '',
         address: '',
-        roomUrl: '',
+        roomUrl: 'demo-url', // need a non-empty value to avoid exception
         usable: true,
         project: 'default',
       }),
@@ -212,7 +212,7 @@ describe('new PageSpy([config])', () => {
       JSON.stringify({
         name: '',
         address: '',
-        roomUrl: '',
+        roomUrl: 'demo-url', // need a non-empty value to avoid exception
         usable: false,
         project: 'default',
       }),

--- a/packages/page-spy-uniapp/src/index.ts
+++ b/packages/page-spy-uniapp/src/index.ts
@@ -4,7 +4,7 @@ import Device from 'mp-base/src/device';
 import { SpyDevice } from 'packages/page-spy-types';
 import { SocketStoreBase } from 'base/src/socket-base';
 import { psLog } from 'base/src';
-import { MPSocketWrapper } from 'mp-base/src/helpers/socket';
+import { MPSocketImpl } from 'mp-base/src/helpers/socket';
 
 declare const uni: any;
 
@@ -60,7 +60,7 @@ if (
   info.uniPlatform === 'mp-alipay' &&
   (info.hostName === 'DingTalk' || info.hostName === 'mPaaS')
 ) {
-  MPSocketWrapper.isSingleSocket = true;
+  MPSocketImpl.isSingleSocket = true;
 }
 
 // Really disgusting... alipay mp has different message format even in uniapp...

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,11 +1078,6 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz#e5211452df060fa8522b55c7b3c0c4d1981cb044"
   integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
 
-"@huolala-tech/page-spy-types@^1.7.6":
-  version "1.7.6"
-  resolved "https://registry.npmmirror.com/@huolala-tech/page-spy-types/-/page-spy-types-1.7.6.tgz#cfee6b2241838fba6b21a198ebb85a7349ada513"
-  integrity sha512-9tgxKu8DbcHobS8poM7QxrhoKH6L6/77SfymnSvKRJsd9CctDn11IrNXKHdve78HVnCz65PkXVdhXDwNnWnhOg==
-
 "@hutson/parse-repository-url@^3.0.0":
   version "3.0.2"
   resolved "https://registry.npmjs.org/@hutson/parse-repository-url/-/parse-repository-url-3.0.2.tgz#98c23c950a3d9b6c8f0daed06da6c3af06981340"
@@ -4222,11 +4217,6 @@ eventemitter3@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz#53f5ffd0a492ac800721bb42c66b841de96423c4"
   integrity sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==
-
-events@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
-  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 execa@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## 问题：
因为要优化 socket 连接问题，发现 socket 的抽象不太好。
之前使用了 SocketWrapper 来包装不同平台的 socket 实现。即使是 web 平台也把 WebSocket 包装了一层，完全没有必要。
## 解决方案：
把 SocketWrapper 抽象为接口，并且和浏览器的 WebSocket API 保持一致。其他平台来适配 WebSocket API，浏览器端保持不变。

## 其他
抽象了 EventEmitter，有很多地方用到。这次只应用在 MPSocket，其他地方后面再说。