### PR TITLE
feat: the logo can be hidden in the left/right

### DIFF
--- a/packages/page-spy-browser/src/helpers/moveable.ts
+++ b/packages/page-spy-browser/src/helpers/moveable.ts
@@ -22,6 +22,7 @@ export function moveable(el: UElement) {
   };
   const touch = { x: 0, y: 0 };
   function handleHidden() {
+    // 第一时间计算 el.isHidden，保证点击显示弹窗行为正常
     const { left, width } = el.getBoundingClientRect();
     const criticalX = window.innerWidth - width;
     if (left >= 0 && left <= criticalX) {
@@ -35,9 +36,14 @@ export function moveable(el: UElement) {
       hiddenTimer = null;
       if (el.disableHidden) return;
 
-      if (left <= 0) {
+      // 重新计算 el.getBoundingClientRect（如果 logo 本就隐藏在右侧，宽度会变化）
+      const currentRect = el.getBoundingClientRect();
+      const currentCriticalX = window.innerWidth - currentRect.width;
+
+      if (currentRect.left <= 0) {
         el.classList.add('hidden-in-left');
-      } else if (left >= criticalX) {
+      } else if (currentRect.left >= currentCriticalX) {
+        el.style.left = `${currentCriticalX}px`;
         el.classList.add('hidden-in-right');
       }
       el.isHidden = true;

--- a/packages/page-spy-browser/src/helpers/moveable.ts
+++ b/packages/page-spy-browser/src/helpers/moveable.ts
@@ -4,6 +4,9 @@ export type UElement = HTMLElement & {
   disableHidden: boolean;
 };
 
+const STICKY_RADIUS = '50%';
+const FULLY_RADIUS = '100%';
+
 function getPosition(evt: TouchEvent | MouseEvent): Touch | MouseEvent {
   /* c8 ignore next 3 */
   if (window.TouchEvent && evt instanceof TouchEvent) {
@@ -23,9 +26,8 @@ export function moveable(el: UElement) {
   const touch = { x: 0, y: 0 };
   function handleHidden() {
     // 第一时间计算 el.isHidden，保证点击显示弹窗行为正常
-    const { left, width } = el.getBoundingClientRect();
-    const criticalX = window.innerWidth - width;
-    if (left >= 0 && left <= criticalX) {
+    const { left, top } = el.getBoundingClientRect();
+    if (left >= 0 && left <= critical.xAxis) {
       el.isHidden = false;
     }
 
@@ -36,15 +38,16 @@ export function moveable(el: UElement) {
       hiddenTimer = null;
       if (el.disableHidden) return;
 
-      // 重新计算 el.getBoundingClientRect（如果 logo 本就隐藏在右侧，宽度会变化）
-      const currentRect = el.getBoundingClientRect();
-      const currentCriticalX = window.innerWidth - currentRect.width;
-
-      if (currentRect.left <= 0) {
+      if (left <= 0) {
         el.classList.add('hidden-in-left');
-      } else if (currentRect.left >= currentCriticalX) {
-        el.style.left = `${currentCriticalX}px`;
+      } else if (left >= critical.xAxis) {
         el.classList.add('hidden-in-right');
+      }
+
+      if (top <= 0) {
+        el.classList.add('hidden-in-top');
+      } else if (top >= critical.yAxis) {
+        el.classList.add('hidden-in-bottom');
       }
       el.isHidden = true;
     }, 1000);
@@ -57,16 +60,26 @@ export function moveable(el: UElement) {
     const diffY = clientY - touch.y;
     let resultX = rect.x + diffX;
     /* c8 ignore start */
-    if (resultX < 0) {
+    if (resultX <= 0) {
       resultX = 0;
-    } else if (resultX > critical.xAxis) {
+      el.style.setProperty('--left-radius', STICKY_RADIUS);
+    } else if (resultX >= critical.xAxis) {
       resultX = critical.xAxis;
+      el.style.setProperty('--right-radius', STICKY_RADIUS);
+    } else {
+      el.style.setProperty('--left-radius', FULLY_RADIUS);
+      el.style.setProperty('--right-radius', FULLY_RADIUS);
     }
     let resultY = rect.y + diffY;
-    if (resultY < 0) {
+    if (resultY <= 0) {
       resultY = 0;
+      el.style.setProperty('--top-radius', STICKY_RADIUS);
     } else if (resultY > critical.yAxis) {
       resultY = critical.yAxis;
+      el.style.setProperty('--bottom-radius', STICKY_RADIUS);
+    } else {
+      el.style.setProperty('--top-radius', FULLY_RADIUS);
+      el.style.setProperty('--bottom-radius', FULLY_RADIUS);
     }
     /* c8 ignore stop */
 
@@ -89,7 +102,12 @@ export function moveable(el: UElement) {
       clearTimeout(hiddenTimer);
     }
     if (el.isHidden) {
-      el.classList.remove('hidden-in-left', 'hidden-in-right');
+      el.classList.remove(
+        'hidden-in-top',
+        'hidden-in-right',
+        'hidden-in-bottom',
+        'hidden-in-left',
+      );
     }
     el.isMoveEvent = false;
     rect = el.getBoundingClientRect();
@@ -116,7 +134,12 @@ export function moveable(el: UElement) {
     () => {
       el.disableHidden = true;
       if (el.isHidden) {
-        el.classList.remove('hidden-in-left', 'hidden-in-right');
+        el.classList.remove(
+          'hidden-in-top',
+          'hidden-in-right',
+          'hidden-in-bottom',
+          'hidden-in-left',
+        );
       }
     },
     false,

--- a/packages/page-spy-browser/src/index.less
+++ b/packages/page-spy-browser/src/index.less
@@ -8,7 +8,7 @@
   font-size: @fontSize;
   .page-spy-logo {
     position: fixed;
-    left: (20em / @fontSize);
+    right: (20em / @fontSize);
     bottom: (80em / @fontSize);
     display: flex;
     justify-content: center;

--- a/packages/page-spy-browser/src/index.less
+++ b/packages/page-spy-browser/src/index.less
@@ -44,6 +44,9 @@
       .hidden-mixin;
       transform: translateX((60em / @fontSize));
     }
+    img {
+      display: block;
+    }
   }
   .page-spy-modal {
     position: fixed;

--- a/packages/page-spy-browser/src/index.less
+++ b/packages/page-spy-browser/src/index.less
@@ -1,6 +1,7 @@
 @primary-color: #9a62e4;
 @gradient: linear-gradient(45deg, #efdfff, #4e00b1 52%, #3d0c7c);
 @size: 80em;
+@hidden-size: 40em;
 @fontSize: 14px;
 
 #__pageSpy {
@@ -20,10 +21,28 @@
     box-shadow: 0px 4px 8px 2px rgba(0, 0, 0, 0.2);
     cursor: pointer;
     z-index: 13000;
-    transition: background-color filter ease-in-out 0.3s;
+    transition:
+      transform ease-in-out 0.3s,
+      width ease-in-out 0.3s 0.3s,
+      border-radius ease-in-out 0.3s 0.3s,
+      background-color ease-in-out 0.3s,
+      filter ease-in-out 0.3s;
     &.inactive {
       background-color: #a2a2a2;
       filter: grayscale(1);
+    }
+
+    .hidden-mixin {
+      width: (@hidden-size / @fontSize);
+      border-radius: 6px;
+    }
+    &.hidden-in-left {
+      .hidden-mixin;
+      transform: translateX(-50%);
+    }
+    &.hidden-in-right {
+      .hidden-mixin;
+      transform: translateX((60em / @fontSize));
     }
   }
   .page-spy-modal {

--- a/packages/page-spy-browser/src/index.less
+++ b/packages/page-spy-browser/src/index.less
@@ -2,29 +2,32 @@
 @gradient: linear-gradient(45deg, #efdfff, #4e00b1 52%, #3d0c7c);
 @size: 80em;
 @hidden-size: 40em;
-@fontSize: 14px;
+@font-size: 14px;
 
 #__pageSpy {
-  font-size: @fontSize;
+  font-size: @font-size;
   .page-spy-logo {
+    --top-radius: 100%;
+    --right-radius: 100%;
+    --bottom-radius: 100%;
+    --left-radius: 100%;
     position: fixed;
-    right: (20em / @fontSize);
-    bottom: (80em / @fontSize);
+    right: (40em / @font-size);
+    bottom: (80em / @font-size);
     display: flex;
     justify-content: center;
     align-items: center;
-    width: (@size / @fontSize);
-    height: (@size / @fontSize);
-    font-size: (14em / @fontSize);
-    border-radius: (@size / @fontSize);
+    width: (@size / @font-size);
+    height: (@size / @font-size);
+    font-size: (14em / @font-size);
+    border-radius: (@size / @font-size);
     background-color: #fff;
     box-shadow: 0px 4px 8px 2px rgba(0, 0, 0, 0.2);
     cursor: pointer;
     z-index: 13000;
     transition:
+      opacity ease-in-out 0.3s,
       transform ease-in-out 0.3s,
-      width ease-in-out 0.3s 0.3s,
-      border-radius ease-in-out 0.3s 0.3s,
       background-color ease-in-out 0.3s,
       filter ease-in-out 0.3s;
     &.inactive {
@@ -32,20 +35,61 @@
       filter: grayscale(1);
     }
 
-    .hidden-mixin {
-      width: (@hidden-size / @fontSize);
-      border-radius: 6px;
+    &::after {
+      content: '';
+      display: block;
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 100%;
+      height: 100%;
+      transform: rotateZ(45deg);
+      background-color: white;
+      border-top-left-radius: var(--top-radius);
+      border-top-right-radius: var(--right-radius);
+      border-bottom-right-radius: var(--bottom-radius);
+      border-bottom-left-radius: var(--left-radius);
+      transition: border-radius linear 0.15s;
     }
-    &.hidden-in-left {
+
+    .hidden-mixin {
+      opacity: 0.35;
+    }
+    @logo-hidden-translate: 65%;
+    @img-hidden-translate: 30%;
+    &.hidden-in-top {
       .hidden-mixin;
-      transform: translateX(-50%);
+      transform: translateY(-(@logo-hidden-translate));
+      img {
+        transform: translateY(@img-hidden-translate);
+      }
     }
     &.hidden-in-right {
       .hidden-mixin;
-      transform: translateX((60em / @fontSize));
+      transform: translateX(@logo-hidden-translate);
+      img {
+        transform: translateX(-(@img-hidden-translate));
+      }
+    }
+    &.hidden-in-bottom {
+      .hidden-mixin;
+      transform: translateY(@logo-hidden-translate);
+      img {
+        transform: translateY(-(@img-hidden-translate));
+      }
+    }
+    &.hidden-in-left {
+      .hidden-mixin;
+      transform: translateX(-(@logo-hidden-translate));
+      img {
+        transform: translateX(@img-hidden-translate);
+      }
     }
     img {
+      position: relative;
       display: block;
+      z-index: 100;
+      transition: transform ease-in-out 0.1s 0.4s;
     }
   }
   .page-spy-modal {
@@ -67,13 +111,13 @@
   }
   .page-spy-content {
     width: 75%;
-    max-width: (350em / @fontSize);
+    max-width: (350em / @font-size);
     background-color: #fafafa;
-    border-radius: (4em / @fontSize);
+    border-radius: (4em / @font-size);
     text-align: center;
     &__info {
-      padding: (24em / @fontSize) (16em / @fontSize);
-      font-size: (16em / @fontSize);
+      padding: (24em / @font-size) (16em / @font-size);
+      font-size: (16em / @font-size);
       line-height: 1.5;
       text-align: left;
       color: #202124;
@@ -86,16 +130,16 @@
         text-overflow: ellipsis;
         b {
           display: inline-block;
-          width: (92em / @fontSize);
+          width: (92em / @font-size);
           text-align: right;
           margin-right: 10px;
         }
       }
     }
     &__btn {
-      padding: (8em / @fontSize) 0;
+      padding: (8em / @font-size) 0;
       border-top: 1px solid #eee;
-      font-size: (16em / @fontSize);
+      font-size: (16em / @font-size);
       line-height: 1.5;
       color: transparent;
       background-clip: text;
@@ -117,7 +161,7 @@
   white-space: nowrap;
   padding: 6px 12px;
   color: @primary-color;
-  font-size: @fontSize;
+  font-size: @font-size;
   background-color: #fafafa;
   border-radius: 4px;
   box-shadow: 0px 4px 8px 2px rgba(0, 0, 0, 0.2);

--- a/packages/page-spy-browser/src/index.ts
+++ b/packages/page-spy-browser/src/index.ts
@@ -331,9 +331,9 @@ class PageSpy {
     root.insertAdjacentElement('beforeend', modal.el);
 
     function showModal(e: any) {
-      const { isMoveEvent } = logo as unknown as UElement;
+      const { isMoveEvent, isHidden } = logo as unknown as UElement;
       /* c8 ignore next 3 */
-      if (isMoveEvent) {
+      if (isMoveEvent || isHidden) {
         return;
       }
       e.stopPropagation();
@@ -342,7 +342,7 @@ class PageSpy {
     logo.addEventListener('click', showModal, false);
     logo.addEventListener('touchend', showModal, false);
     document.documentElement.insertAdjacentElement('beforeend', root);
-    moveable(logo);
+    moveable(logo as unknown as UElement);
     this.triggerPlugins('onMounted', {
       root,
       content: content.el,


### PR DESCRIPTION
## Related

close https://github.com/HuolalaTech/page-spy-web/issues/171

## Changes

1. SDK 渲染的悬浮球拖拽到屏幕上、下、左、右侧时会自动收起，鼠标滑过或点击展开；
2. 悬浮球初始化在右侧；

![May-11-2024 09-58-57](https://github.com/HuolalaTech/page-spy/assets/23474513/41bf4c49-d7a1-4923-96b7-6c592d6055f0)
