### PR TITLE
fix: correct the btn text content by 'triggerPlugins'

### DIFF
--- a/packages/page-spy-plugin-data-harbor/src/index.ts
+++ b/packages/page-spy-plugin-data-harbor/src/index.ts
@@ -155,15 +155,19 @@ export default class DataHarborPlugin implements PageSpyPlugin {
   }
 
   onOfflineLog(type: 'download' | 'upload') {
-    switch (type) {
-      case 'download':
-        startDownload(this.getParams('download'));
-        break;
-      case 'upload':
-        startUpload(this.getParams('upload'));
-        break;
-      default:
-        break;
+    try {
+      switch (type) {
+        case 'download':
+          startDownload(this.getParams('download'));
+          break;
+        case 'upload':
+          startUpload(this.getParams('upload'));
+          break;
+        default:
+          break;
+      }
+    } catch (e: any) {
+      psLog.error(e.message);
     }
   }
 

--- a/packages/page-spy-plugin-data-harbor/src/index.ts
+++ b/packages/page-spy-plugin-data-harbor/src/index.ts
@@ -154,15 +154,16 @@ export default class DataHarborPlugin implements PageSpyPlugin {
     } as UploadArgs;
   }
 
-  onOfflineLog(type: 'download' | 'upload') {
+  // eslint-disable-next-line consistent-return
+  async onOfflineLog(type: 'download' | 'upload') {
     try {
       switch (type) {
         case 'download':
           startDownload(this.getParams('download'));
           break;
         case 'upload':
-          startUpload(this.getParams('upload'));
-          break;
+          const url = await startUpload(this.getParams('upload'));
+          return url;
         default:
           break;
       }

--- a/packages/page-spy-plugin-data-harbor/src/utils/download.ts
+++ b/packages/page-spy-plugin-data-harbor/src/utils/download.ts
@@ -18,14 +18,8 @@ export const startDownload = async ({
   filename,
   customDownload,
 }: DownloadArgs) => {
-  const downloadBtn: HTMLDivElement | null = document.querySelector(
-    '#data-harbor-plugin-download',
-  );
   const data = await harbor.getHarborData();
   if (customDownload) {
-    if (downloadBtn) {
-      downloadBtn.textContent = TIPS.ready;
-    }
     await customDownload(data);
     return;
   }
@@ -35,10 +29,9 @@ export const startDownload = async ({
   const root: HTMLElement =
     document.getElementsByTagName('body')[0] || document.documentElement;
   if (!root) {
-    psLog.error(
+    throw new Error(
       'Download file failed because cannot find the document.body & document.documentElement',
     );
-    return;
   }
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -73,9 +66,9 @@ export const handleDownload = ({
       downloadBtn.textContent = TIPS.readying;
       await startDownload({ harbor, filename, customDownload });
       downloadBtn.textContent = TIPS.success;
-    } catch (e) {
+    } catch (e: any) {
       downloadBtn.textContent = TIPS.fail;
-      psLog.error('Download failed.', e);
+      psLog.error('Download failed.', e.message);
     } finally {
       setTimeout(() => {
         downloadBtn.textContent = TIPS.normal;

--- a/packages/page-spy-plugin-data-harbor/src/utils/upload.ts
+++ b/packages/page-spy-plugin-data-harbor/src/utils/upload.ts
@@ -26,10 +26,6 @@ export const startUpload = async ({
   debugClient,
   tags = {},
 }: UploadArgs) => {
-  const uploadBtn: HTMLDivElement | null = document.querySelector(
-    '#data-harbor-plugin-upload',
-  );
-
   const data = await harbor.getHarborData();
   const blob = new Blob([JSON.stringify(data)], {
     type: 'application/json',
@@ -39,10 +35,6 @@ export const startUpload = async ({
   });
   const form = new FormData();
   form.append('log', file);
-
-  if (uploadBtn) {
-    uploadBtn.textContent = TIPS.uploading;
-  }
 
   const response = await fetch(
     `${uploadUrl}/api/v1/log/upload?${new URLSearchParams(tags).toString()}`,
@@ -93,7 +85,7 @@ export const handleUpload = ({
     idleWithUpload = false;
 
     try {
-      uploadBtn.textContent = TIPS.readying;
+      uploadBtn.textContent = TIPS.uploading;
       const debugUrl = await startUpload({
         harbor,
         filename,


### PR DESCRIPTION
1. 🐛 修复发送代码到客户端执行、触发上传 / 下载时按钮文案未重置的问题；
2. 🆕 `harbor.onOfflineLog('upload')` 返回上传之后的 URL，便于用户在业务中集成；

```js
window.$harbor = new DataHarborPlugin()

async function uploadLogManually() {
  const debugUrl = await window.$harbor.onOfflineLog('upload')
  console.log({ debugUrl })
}
```