### PR TITLE
optimize the time of socket send data

### DIFF
--- a/packages/base/src/socket-base.ts
+++ b/packages/base/src/socket-base.ts
@@ -480,7 +480,13 @@ export abstract class SocketStoreBase {
 
   private checkIfSend(msg: SpySocket.ClientEvent) {
     if (this.socketWrapper.getState() !== SocketState.OPEN) return false;
-    if (msg.type === SERVER_MESSAGE_TYPE.PING) return true;
+    if (
+      [SERVER_MESSAGE_TYPE.UPDATE_ROOM_INFO, SERVER_MESSAGE_TYPE.PING].includes(
+        msg.type,
+      )
+    ) {
+      return true;
+    }
 
     if (!this.debuggerConnection) return false;
     return true;

--- a/packages/base/src/socket-base.ts
+++ b/packages/base/src/socket-base.ts
@@ -230,6 +230,7 @@ export abstract class SocketStoreBase {
   private connectOffline() {
     this.connectionStatus = false;
     this.socketConnection = null;
+    this.debuggerConnection = null;
     this.clearPing();
     if (this.retryTimer) {
       clearTimeout(this.retryTimer);

--- a/packages/base/src/socket-base.ts
+++ b/packages/base/src/socket-base.ts
@@ -337,6 +337,7 @@ export abstract class SocketStoreBase {
           });
         }
         break;
+      case CLOSE:
       case ERROR:
         // TODO: we should handle this error
         // if (result.content.code === 'RoomNotFoundError') {
@@ -347,7 +348,6 @@ export abstract class SocketStoreBase {
       /* c8 ignore start */
       case PONG:
       case PING:
-      case CLOSE:
       case BROADCAST:
       default:
         // noting

--- a/packages/mp-base/src/index.ts
+++ b/packages/mp-base/src/index.ts
@@ -102,6 +102,7 @@ class PageSpy {
       psLog.log(`Room Secret: ${secret}`);
     }
 
+    socketStore.connectable = true;
     socketStore.getPageSpyConfig = () => this.config.get();
     socketStore.messageCapacity = messageCapacity;
   }

--- a/packages/page-spy-browser/src/index.ts
+++ b/packages/page-spy-browser/src/index.ts
@@ -111,7 +111,10 @@ class PageSpy {
       // reconnect when page switch to front-ground.
       document.addEventListener('visibilitychange', () => {
         // For browser, if the connection exist, no need to recreate.
-        if (!document.hidden && !socketStore.connectionStatus) {
+        if (
+          !document.hidden &&
+          socketStore.getSocket().getState() !== SocketState.OPEN
+        ) {
           this.useOldConnection();
         }
       });

--- a/packages/page-spy-browser/src/index.ts
+++ b/packages/page-spy-browser/src/index.ts
@@ -113,7 +113,8 @@ class PageSpy {
         // For browser, if the connection exist, no need to recreate.
         if (
           !document.hidden &&
-          socketStore.getSocket().getState() !== SocketState.OPEN
+          socketStore.getSocket().getState() !== SocketState.OPEN &&
+          socketStore.connectable
         ) {
           this.useOldConnection();
         }

--- a/packages/page-spy-browser/src/index.ts
+++ b/packages/page-spy-browser/src/index.ts
@@ -82,6 +82,7 @@ class PageSpy {
       );
       this.config.set('secret', cache?.secret || getAuthSecret());
     }
+    socketStore.connectable = true;
     socketStore.getPageSpyConfig = () => this.config.get();
     socketStore.isOffline = offline;
     socketStore.messageCapacity = messageCapacity;

--- a/packages/page-spy-browser/tests/helpers/socket.test.ts
+++ b/packages/page-spy-browser/tests/helpers/socket.test.ts
@@ -6,6 +6,7 @@ import type {
 } from '@huolala-tech/page-spy-types/lib/socket-event';
 import * as SERVER_MESSAGE_TYPE from 'base/src/message/server-type';
 import { SpyMessage } from '@huolala-tech/page-spy-types';
+import { SocketState } from 'base/src/socket-base';
 // Mock micro task delay
 const sleep = (t = 100) => new Promise((r) => setTimeout(r, t));
 
@@ -30,13 +31,13 @@ describe('Socket store', () => {
     jest.useFakeTimers();
     // @ts-ignore
     const reconnect = jest.spyOn(client, 'tryReconnect');
-    expect(client.connectionStatus).toBe(true);
+    expect(client.getSocket().getState()).toBe(SocketState.OPEN);
     client.getSocket()?.close();
 
     jest.advanceTimersByTime(2000 + 500);
 
     expect(reconnect).toHaveBeenCalledTimes(1);
-    expect(client.connectionStatus).toBe(true);
+    expect(client.getSocket().getState()).toBe(SocketState.OPEN);
   });
 
   it('Reconnect time will increase exponentially, and will be fixed to 4 times increased.', async () => {
@@ -61,11 +62,11 @@ describe('Socket store', () => {
   });
 
   it('Stop', async () => {
-    expect(client.connectionStatus).toBe(true);
+    expect(client.getSocket().getState()).toBe(SocketState.OPEN);
     client.close();
 
     await sleep();
-    expect(client.connectionStatus).toBe(false);
+    expect(client.getSocket().getState()).not.toBe(SocketState.OPEN);
   });
 
   it('Message type', async () => {
@@ -124,6 +125,6 @@ describe('Socket store', () => {
     };
     server.send(errMsg);
     await sleep();
-    expect(client.connectionStatus).toBe(false);
+    expect(client.getSocket().getState()).not.toBe(SocketState.OPEN);
   });
 });

--- a/packages/page-spy-browser/tests/helpers/socket.test.ts
+++ b/packages/page-spy-browser/tests/helpers/socket.test.ts
@@ -124,7 +124,8 @@ describe('Socket store', () => {
       },
     };
     server.send(errMsg);
-    await sleep();
+    // sleep time here be 2000 is for SDK will auto reconnect after 2000ms
+    await sleep(2000);
     expect(client.getSocket().getState()).not.toBe(SocketState.OPEN);
   });
 });

--- a/packages/page-spy-plugin-data-harbor/rollup.config.mjs
+++ b/packages/page-spy-plugin-data-harbor/rollup.config.mjs
@@ -64,6 +64,7 @@ export default [
       file: pkg.main,
       format: 'iife',
       name: 'DataHarborPlugin',
+      sourcemap: true
     },
     plugins: [
       ...plugins,
@@ -76,6 +77,7 @@ export default [
     output: {
       file: pkg.module,
       format: 'esm',
+      sourcemap: true
     },
     plugins: [
       ...plugins,

--- a/packages/page-spy-plugin-rrweb/rollup.config.mjs
+++ b/packages/page-spy-plugin-rrweb/rollup.config.mjs
@@ -65,6 +65,7 @@ export default [
       file: pkg.main,
       format: 'iife',
       name: 'RRWebPlugin',
+      sourcemap: true,
     },
     plugins: [
       ...plugins,
@@ -77,6 +78,7 @@ export default [
     output: {
       file: pkg.module,
       format: 'esm',
+      sourcemap: true,
     },
     plugins: [
       ...plugins,


### PR DESCRIPTION
1. 优化：调试端不连上来，不发消息；
2. 新增 `psLog.unproxy.<fn>` ：用于本地开发调试、或者打印的内容不希望输出到调试端；
3. 修复连接超时后，重连会自动断开、再次重连、再次自动断开……；
4. 修复 `$pageSpy.abort()`；
5. `harbor` 和 `rrweb` 插件输出 sourcemap；