### PR TITLE
fix: accidentally clear some listeners when call `$pageSpy.abort`

### DIFF
--- a/packages/base/src/socket-base.ts
+++ b/packages/base/src/socket-base.ts
@@ -223,7 +223,11 @@ export abstract class SocketStoreBase {
     this.clearPing();
     this.socketWrapper?.close();
     this.messages = [];
-    Object.entries(this.events).forEach(([, fns]) => {
+    Object.entries(this.events).forEach(([evt, fns]) => {
+      // 这三个事件的生命周期跟随 socketStore
+      if (['atom-detail', 'atom-getter', 'debugger-online'].includes(evt)) {
+        return;
+      }
       fns.splice(0);
     });
   }


### PR DESCRIPTION
fix https://github.com/HuolalaTech/page-spy-web/issues/205