### PR TITLE
feat: support modify data 

### DIFF
--- a/packages/page-spy-base/src/config.ts
+++ b/packages/page-spy-base/src/config.ts
@@ -3,8 +3,6 @@ export abstract class ConfigBase<C extends Record<string, any>> {
 
   protected value: Required<C>;
 
-  // eslint disable: have to use generic type here
-  /* eslint-disable-next-line class-methods-use-this */
   protected defaultConfig() {
     return {} as Required<C>;
   }

--- a/packages/page-spy-base/src/network/base.ts
+++ b/packages/page-spy-base/src/network/base.ts
@@ -44,7 +44,12 @@ export class NetworkProxyBase {
     return true;
   }
 
+  public static dataProcessor?: (data: RequestItem) => boolean;
+
   protected sendRequestItem(id: string, req: RequestItem) {
+    const processedByUser = NetworkProxyBase.dataProcessor?.(req);
+    if (processedByUser === false) return;
+
     try {
       if (!this.reqMap[id]) {
         this.reqMap[id] = req;

--- a/packages/page-spy-browser/src/config.ts
+++ b/packages/page-spy-browser/src/config.ts
@@ -69,6 +69,11 @@ export class Config extends ConfigBase<InitConfig> {
       useSecret: false,
       secret: '',
       serializeData: false,
+      dataProcessor: {
+        console: () => true,
+        network: () => true,
+        storage: () => true,
+      },
     };
 
     if (!Config.scriptLink) {

--- a/packages/page-spy-browser/src/config.ts
+++ b/packages/page-spy-browser/src/config.ts
@@ -69,11 +69,7 @@ export class Config extends ConfigBase<InitConfig> {
       useSecret: false,
       secret: '',
       serializeData: false,
-      dataProcessor: {
-        console: () => true,
-        network: () => true,
-        storage: () => true,
-      },
+      dataProcessor: {},
     };
 
     if (!Config.scriptLink) {

--- a/packages/page-spy-browser/src/plugins/console.ts
+++ b/packages/page-spy-browser/src/plugins/console.ts
@@ -98,6 +98,10 @@ export default class ConsolePlugin implements PageSpyPlugin {
     if (data.logs && data.logs.length) {
       this.console[data.logType](...data.logs);
 
+      const processedByUser =
+        this.$pageSpyConfig?.dataProcessor?.console?.(data);
+      if (processedByUser === false) return;
+
       const atomLog = makeMessage('console', {
         ...data,
         time: Date.now(),

--- a/packages/page-spy-browser/src/plugins/console.ts
+++ b/packages/page-spy-browser/src/plugins/console.ts
@@ -96,12 +96,11 @@ export default class ConsolePlugin implements PageSpyPlugin {
 
   public printLog(data: SpyConsole.DataItem) {
     if (data.logs && data.logs.length) {
-      this.console[data.logType](...data.logs);
-
       const processedByUser =
         this.$pageSpyConfig?.dataProcessor?.console?.(data);
       if (processedByUser === false) return;
 
+      this.console[data.logType](...data.logs);
       const atomLog = makeMessage('console', {
         ...data,
         time: Date.now(),

--- a/packages/page-spy-browser/src/plugins/console.ts
+++ b/packages/page-spy-browser/src/plugins/console.ts
@@ -33,6 +33,10 @@ export default class ConsolePlugin implements PageSpyPlugin {
     socketStore.addListener('debug', ConsolePlugin.handleDebugger);
 
     this.$pageSpyConfig = config;
+    this.init();
+  }
+
+  public init() {
     this.proxyTypes.forEach((item) => {
       this.console[item] =
         window.console[item] || window.console.log || (() => {});
@@ -46,10 +50,14 @@ export default class ConsolePlugin implements PageSpyPlugin {
     });
   }
 
-  public onReset() {
+  public reset() {
     this.proxyTypes.forEach((item) => {
       window.console[item] = this.console[item];
     });
+  }
+
+  public onReset() {
+    this.reset();
     ConsolePlugin.hasInitd = false;
   }
 
@@ -96,9 +104,14 @@ export default class ConsolePlugin implements PageSpyPlugin {
 
   public printLog(data: SpyConsole.DataItem) {
     if (data.logs && data.logs.length) {
-      const processedByUser =
-        this.$pageSpyConfig?.dataProcessor?.console?.(data);
-      if (processedByUser === false) return;
+      const processor = this.$pageSpyConfig?.dataProcessor?.console;
+      if (processor) {
+        this.reset();
+        const processedByUser = processor(data);
+        this.init();
+
+        if (processedByUser === false) return;
+      }
 
       this.console[data.logType](...data.logs);
       const atomLog = makeMessage('console', {

--- a/packages/page-spy-browser/src/plugins/network/index.ts
+++ b/packages/page-spy-browser/src/plugins/network/index.ts
@@ -1,9 +1,11 @@
 // eslint-disable no-case-declarations
-import type { PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import type { OnInitParams, PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import { NetworkProxyBase } from '@huolala-tech/page-spy-base';
 import XhrProxy from './proxy/xhr-proxy';
 import FetchProxy from './proxy/fetch-proxy';
 import BeaconProxy from './proxy/beacon-proxy';
 import SSEProxy from './proxy/sse-proxy';
+import { InitConfig } from '../../config';
 
 export default class NetworkPlugin implements PageSpyPlugin {
   public name = 'NetworkPlugin';
@@ -18,9 +20,10 @@ export default class NetworkPlugin implements PageSpyPlugin {
 
   public static hasInitd = false;
 
-  public onInit() {
+  public onInit({ config }: OnInitParams<InitConfig>) {
     if (NetworkPlugin.hasInitd) return;
     NetworkPlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
 
     this.xhrProxy = new XhrProxy();
     this.fetchProxy = new FetchProxy();

--- a/packages/page-spy-browser/tests/env.d.ts
+++ b/packages/page-spy-browser/tests/env.d.ts
@@ -1,0 +1,49 @@
+/* eslint-disable @typescript-eslint/no-redeclare */
+/* eslint-disable vars-on-top */
+/* eslint-disable no-var */
+
+import { CookieStoreValue } from '@huolala-tech/page-spy-types/lib/storage';
+
+declare global {
+  declare module '*.svg' {
+    const content: string;
+    export default content;
+  }
+  declare module '*.png' {
+    const content: string;
+    export default content;
+  }
+  interface CookieChangeEvent extends Event {
+    changed: CookieStoreValue[];
+    deleted: CookieStoreValue[];
+  }
+
+  type OptionName = {
+    name: string;
+    /**
+     * @default false
+     */
+    partitioned?: boolean;
+    path?: string;
+    url?: string;
+  };
+
+  interface CookieStoreEventTarget extends EventTarget {
+    delete(name: OptionName | string): Promise<void>;
+    get(name: OptionName | string): Promise<null | CookieStoreValue>;
+    getAll(): Promise<CookieStoreValue[]>;
+    set(name: string, value: string): Promise<void>;
+    set(name: OptionName): Promise<void>;
+  }
+
+  var CookieStore: {
+    prototype: CookieStoreEventTarget;
+    new (): CookieStoreEventTarget;
+  };
+
+  var cookieStore: CookieStoreEventTarget;
+
+  var Modernizr: any;
+
+  var PKG_VERSION: string;
+}

--- a/packages/page-spy-browser/tests/init.test.ts
+++ b/packages/page-spy-browser/tests/init.test.ts
@@ -5,13 +5,20 @@ import NetworkPlugin from 'page-spy-browser/src/plugins/network';
 import SystemPlugin from 'page-spy-browser/src/plugins/system';
 import PagePlugin from 'page-spy-browser/src/plugins/page';
 import { StoragePlugin } from 'page-spy-browser/src/plugins/storage';
-import { SpyConsole } from '@huolala-tech/page-spy-types';
+import { OnInitParams, SpyConsole } from '@huolala-tech/page-spy-types';
 import socketStore from 'page-spy-browser/src/helpers/socket';
-import { ROOM_SESSION_KEY } from 'page-spy-base/src';
+import { atom, ROOM_SESSION_KEY } from 'page-spy-base/src';
 import { isBrowser } from 'page-spy-base/src';
 import Request from 'page-spy-browser/src/api';
 import { DatabasePlugin } from 'page-spy-browser/src/plugins/database';
+import { Config, InitConfig } from 'page-spy-browser/src/config';
+import socket from 'page-spy-browser/src/helpers/socket';
 
+const initParams = {
+  config: new Config().mergeConfig({}),
+  socketStore: socket,
+  atom,
+} as OnInitParams<InitConfig>;
 const sleep = (t = 100) => new Promise((r) => setTimeout(r, t));
 
 let sdk: SDK | null;
@@ -97,7 +104,7 @@ describe('new PageSpy([config])', () => {
     expect(Object.keys(cPlugin.console)).toHaveLength(0);
 
     // changed!
-    cPlugin.onInit({} as any);
+    cPlugin.onInit(initParams);
     expect(consoleKey.map((i) => console[i])).not.toEqual(originConsole);
     // @ts-ignore
     expect(Object.keys(cPlugin.console)).toHaveLength(consoleKey.length);
@@ -111,7 +118,7 @@ describe('new PageSpy([config])', () => {
     );
 
     // changed!
-    new StoragePlugin().onInit();
+    new StoragePlugin().onInit(initParams);
     expect(protoKey.map((i) => Storage.prototype[i])).not.toEqual(
       originProtoMethods,
     );
@@ -132,7 +139,7 @@ describe('new PageSpy([config])', () => {
     const originBeacon = window.navigator.sendBeacon;
 
     // changed!
-    new NetworkPlugin().onInit();
+    new NetworkPlugin().onInit(initParams);
     expect(
       xhrProtoKey.map((i) => window.XMLHttpRequest.prototype[i]),
     ).not.toEqual(originXhrProtoMethods);

--- a/packages/page-spy-browser/tests/plugins/database.test.ts
+++ b/packages/page-spy-browser/tests/plugins/database.test.ts
@@ -4,10 +4,18 @@ import {
   promisify,
 } from 'page-spy-browser/src/plugins/database';
 import socket from 'page-spy-browser/src/helpers/socket';
+import { OnInitParams } from 'packages/page-spy-types';
+import { Config, InitConfig } from 'page-spy-browser/src/config';
+import { atom } from 'page-spy-base/dist';
 
+const initParams = {
+  config: new Config().mergeConfig({}),
+  socketStore: socket,
+  atom,
+} as OnInitParams<InitConfig>;
 const sleep = (t = 100) => new Promise((r) => setTimeout(r, t));
 // @ts-ignore
-const dbTrigger = jest.spyOn(DatabasePlugin, 'sendData');
+const dbTrigger = jest.spyOn(DatabasePlugin.prototype, 'sendData');
 
 // init indexedDB store and fill data
 beforeEach(async () => {
@@ -41,7 +49,7 @@ describe('Database plugin', () => {
 
     expect(DatabasePlugin.isSupport).toBe(false);
 
-    new DatabasePlugin().onInit();
+    new DatabasePlugin().onInit(initParams);
 
     expect(DatabasePlugin.hasInitd).toBe(false);
 
@@ -52,7 +60,7 @@ describe('Database plugin', () => {
     const db = await indexedDB.databases();
     expect(db.length).toBe(1);
 
-    new DatabasePlugin().onInit();
+    new DatabasePlugin().onInit(initParams);
 
     await promisify(indexedDB.deleteDatabase('blog'));
     const db2 = await indexedDB.databases();
@@ -71,7 +79,7 @@ describe('Database plugin', () => {
     // @ts-ignore
     const originDelete = jest.spyOn(IDBObjectStore.prototype, 'delete');
 
-    new DatabasePlugin().onInit();
+    new DatabasePlugin().onInit(initParams);
 
     const db = await promisify(window.indexedDB.open('blog'));
     const store = db.transaction('posts', 'readwrite').objectStore('posts');
@@ -94,7 +102,7 @@ describe('Database plugin', () => {
   });
 
   it('DATABASE_PAGINATION event and REFRESH event', async () => {
-    new DatabasePlugin().onInit();
+    new DatabasePlugin().onInit(initParams);
 
     // @ts-ignore
     socket.dispatchEvent('refresh', {

--- a/packages/page-spy-browser/tests/plugins/error.test.ts
+++ b/packages/page-spy-browser/tests/plugins/error.test.ts
@@ -1,10 +1,19 @@
+import { OnInitParams } from 'packages/page-spy-types';
+import { atom } from 'page-spy-base/dist';
+import { Config, InitConfig } from 'page-spy-browser/src/config';
+import socket from 'page-spy-browser/src/helpers/socket';
 import ErrorPlugin from 'page-spy-browser/src/plugins/error';
 
+const initParams = {
+  config: new Config().mergeConfig({}),
+  socketStore: socket,
+  atom,
+} as OnInitParams<InitConfig>;
 beforeAll(() => {
-  new ErrorPlugin().onInit();
+  new ErrorPlugin().onInit(initParams);
 });
 
-const errorOccupied = jest.spyOn(ErrorPlugin, 'sendMessage');
+const errorOccupied = jest.spyOn(ErrorPlugin.prototype, 'sendMessage');
 afterEach(() => {
   errorOccupied.mockClear();
 });

--- a/packages/page-spy-browser/tests/plugins/network/beacon-proxy.test.ts
+++ b/packages/page-spy-browser/tests/plugins/network/beacon-proxy.test.ts
@@ -1,7 +1,16 @@
 import NetworkPlugin from 'page-spy-browser/src/plugins/network';
 import startServer from '../../server/index';
 import { computeRequestMapInfo } from './util';
+import { OnInitParams } from 'packages/page-spy-types';
+import { Config, InitConfig } from 'page-spy-browser/src/config';
+import { atom } from 'page-spy-base/dist';
+import socket from 'page-spy-browser/src/helpers/socket';
 
+const initParams = {
+  config: new Config().mergeConfig({}),
+  socketStore: socket,
+  atom,
+} as OnInitParams<InitConfig>;
 const port = 6699;
 const apiPrefix = `http://localhost:${port}`;
 const stopServer = startServer(port);
@@ -20,13 +29,13 @@ describe('navigator.sendBeacon proxy', () => {
       value: undefined,
       writable: true,
     });
-    new NetworkPlugin().onInit();
+    new NetworkPlugin().onInit(initParams);
     expect(window.navigator.sendBeacon).toBe(undefined);
   });
   it('Wrap the navigator.sendBeacon', async () => {
     const sendBeaconSpy = jest.spyOn(window.navigator, 'sendBeacon');
     expect(window.navigator.sendBeacon).toBe(sendBeaconSpy);
-    new NetworkPlugin().onInit();
+    new NetworkPlugin().onInit(initParams);
     expect(window.navigator.sendBeacon).not.toBe(sendBeaconSpy);
   });
 
@@ -44,7 +53,7 @@ describe('navigator.sendBeacon proxy', () => {
       return true;
     });
     const np = new NetworkPlugin();
-    np.onInit();
+    np.onInit(initParams);
     const { beaconProxy } = np;
     window.navigator.sendBeacon(`${apiPrefix}/posts`);
 
@@ -59,7 +68,7 @@ describe('navigator.sendBeacon proxy', () => {
       return false;
     });
     const np = new NetworkPlugin();
-    np.onInit();
+    np.onInit(initParams);
     const { beaconProxy } = np;
     window.navigator.sendBeacon(`${apiPrefix}/posts`);
 
@@ -71,7 +80,7 @@ describe('navigator.sendBeacon proxy', () => {
 
   it('The SDK record the request information', () => {
     const np = new NetworkPlugin();
-    np.onInit();
+    np.onInit(initParams);
     const { beaconProxy } = np;
     expect(beaconProxy).not.toBe(null);
     expect(computeRequestMapInfo(beaconProxy).size).toBe(0);
@@ -86,7 +95,7 @@ describe('navigator.sendBeacon proxy', () => {
   it('The cached request items will be freed when no longer needed', async () => {
     jest.useFakeTimers();
     const np = new NetworkPlugin();
-    np.onInit();
+    np.onInit(initParams);
     const { beaconProxy } = np;
     expect(beaconProxy).not.toBe(null);
     expect(computeRequestMapInfo(beaconProxy).size).toBe(0);

--- a/packages/page-spy-browser/tests/plugins/page.test.ts
+++ b/packages/page-spy-browser/tests/plugins/page.test.ts
@@ -1,13 +1,21 @@
 import PagePlugin from 'page-spy-browser/src/plugins/page';
 import socket from 'page-spy-browser/src/helpers/socket';
-// @ts-ignore
+import { OnInitParams } from 'packages/page-spy-types';
+import { Config, InitConfig } from 'page-spy-browser/src/config';
+import { atom } from 'page-spy-base/dist';
+
+const initParams = {
+  config: new Config().mergeConfig({}),
+  socketStore: socket,
+  atom,
+} as OnInitParams<InitConfig>;
 const trigger = jest.spyOn(PagePlugin, 'collectHtml');
 
 describe('Page plugin', () => {
   it('Collect outerHTML', () => {
     expect(trigger).toHaveBeenCalledTimes(0);
 
-    new PagePlugin().onInit();
+    new PagePlugin().onInit(initParams);
     window.dispatchEvent(new Event('load'));
     expect(trigger).toHaveBeenCalledTimes(0);
 

--- a/packages/page-spy-browser/tests/plugins/storage.test.ts
+++ b/packages/page-spy-browser/tests/plugins/storage.test.ts
@@ -1,11 +1,20 @@
+import { OnInitParams } from 'packages/page-spy-types';
+import { atom } from 'page-spy-base/dist';
+import { Config, InitConfig } from 'page-spy-browser/src/config';
+import socket from 'page-spy-browser/src/helpers/socket';
 import { StoragePlugin } from 'page-spy-browser/src/plugins/storage';
 
-// @ts-ignore
-const trigger = jest.spyOn(StoragePlugin, 'sendStorageItem');
+const initParams = {
+  config: new Config().mergeConfig({}),
+  socketStore: socket,
+  atom,
+} as OnInitParams<InitConfig>;
+const trigger = jest.spyOn(StoragePlugin.prototype, 'sendStorageItem');
+const storageInstance = new StoragePlugin();
 const sleep = (t = 100) => new Promise((r) => setTimeout(r, t));
 
 beforeAll(() => {
-  new StoragePlugin().onInit();
+  storageInstance.onInit(initParams);
 });
 afterEach(() => {
   localStorage.clear();
@@ -79,16 +88,15 @@ describe('Storage plugin', () => {
     });
 
     expect(trigger).toHaveBeenCalledTimes(5);
-    // @ts-ignore
-    const storage = StoragePlugin.takeStorage('localStorage');
+    const storage = storageInstance.takeStorage('localStorage');
     expect(storage.data.length).toBe(5);
     expect(storage.data.map((i) => i.name)).toEqual(keys);
   });
 
   it('Response refresh event', async () => {
-    StoragePlugin.sendRefresh('sessionStorage');
-    StoragePlugin.sendRefresh('cookie');
-    StoragePlugin.sendRefresh('localStorage');
+    storageInstance.sendRefresh('sessionStorage');
+    storageInstance.sendRefresh('cookie');
+    storageInstance.sendRefresh('localStorage');
 
     await sleep();
 

--- a/packages/page-spy-browser/tests/plugins/system.test.ts
+++ b/packages/page-spy-browser/tests/plugins/system.test.ts
@@ -1,5 +1,3 @@
-import socket from 'page-spy-browser/src/helpers/socket';
-import SystemPlugin from 'page-spy-browser/src/plugins/system';
 import { computeResult } from 'page-spy-browser/src/plugins/system/feature';
 
 describe('System plugin', () => {

--- a/packages/page-spy-harmony/library/src/main/ets/config.ts
+++ b/packages/page-spy-harmony/library/src/main/ets/config.ts
@@ -17,6 +17,7 @@ export class Config extends ConfigBase<InitConfig> {
       useSecret: false,
       secret: '',
       serializeData: false,
+      dataProcessor: {},
     };
   };
 }

--- a/packages/page-spy-harmony/library/src/main/ets/plugins/console.ts
+++ b/packages/page-spy-harmony/library/src/main/ets/plugins/console.ts
@@ -103,8 +103,11 @@ export default class ConsolePlugin implements PageSpyPlugin {
 
   public printLog(data: SpyConsole.DataItem) {
     if (data.logs && data.logs.length) {
-      this.console[data.logType](...data.logs);
+      const processedByUser =
+        this.$pageSpyConfig?.dataProcessor?.console?.(data);
+      if (processedByUser === false) return;
 
+      this.console[data.logType](...data.logs);
       const atomLog = makeMessage('console', {
         ...data,
         time: Date.now(),

--- a/packages/page-spy-harmony/library/src/main/ets/plugins/network/index.ts
+++ b/packages/page-spy-harmony/library/src/main/ets/plugins/network/index.ts
@@ -1,5 +1,6 @@
 import type { InitConfig, OnInitParams, PageSpyPlugin } from '../../types';
 import { psLog } from '../../utils';
+import NetworkProxyBase from '../../utils/network/base';
 import AxiosProxy from './axios';
 
 export default class NetworkPlugin implements PageSpyPlugin {
@@ -18,6 +19,7 @@ export default class NetworkPlugin implements PageSpyPlugin {
 
     if (NetworkPlugin.hasInitd) return;
     NetworkPlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
 
     this.axiosProxy = new AxiosProxy(axios);
   }

--- a/packages/page-spy-harmony/library/src/main/ets/types/lib/index.d.ts
+++ b/packages/page-spy-harmony/library/src/main/ets/types/lib/index.d.ts
@@ -1,4 +1,10 @@
 import { SocketStoreType } from './base';
+import { DataItem as ConsoleData } from './console';
+import { DataItem as StorageData } from './storage';
+import { DataItem as PageData } from './page';
+import { DataItem as DatabaseData } from './database';
+import { DataItem as SystemData } from './system';
+import { RequestInfo } from './network';
 
 export interface InitConfigBase {
   /**
@@ -53,6 +59,18 @@ export interface InitConfigBase {
    * @default false
    */
   serializeData?: boolean;
+
+  /**
+   *
+   */
+  dataProcessor?: {
+    console?: (data: ConsoleData) => boolean;
+    network?: (data: RequestInfo) => boolean;
+    storage?: (data: StorageData) => boolean;
+    database?: (data: DatabaseData) => boolean;
+    page?: (data: PageData) => boolean;
+    system?: (data: SystemData) => boolean;
+  };
 }
 
 export interface PageSpyBase {

--- a/packages/page-spy-harmony/library/src/main/ets/utils/network/base.ts
+++ b/packages/page-spy-harmony/library/src/main/ets/utils/network/base.ts
@@ -41,7 +41,12 @@ export default class NetworkProxyBase {
     return true;
   }
 
+  public static dataProcessor?: (data: RequestItem) => boolean;
+
   protected sendRequestItem(id: string, req: RequestItem) {
+    const processedByUser = NetworkProxyBase.dataProcessor?.(req);
+    if (processedByUser === false) return;
+
     if (!this.reqMap[id]) {
       this.reqMap[id] = req;
     }

--- a/packages/page-spy-mp-base/src/config.ts
+++ b/packages/page-spy-mp-base/src/config.ts
@@ -5,7 +5,6 @@ export class Config extends ConfigBase<SpyMP.MPInitConfig> {
   protected privateKeys: (keyof SpyMP.MPInitConfig)[] = ['secret'];
 
   // I need to use generic type on this method, so it can't be static
-  /* eslint-disable-next-line class-methods-use-this */
   protected defaultConfig() {
     return {
       api: '',
@@ -19,6 +18,7 @@ export class Config extends ConfigBase<SpyMP.MPInitConfig> {
       useSecret: false,
       secret: '',
       serializeData: false,
+      dataProcessor: {},
     };
   }
 }

--- a/packages/page-spy-mp-base/src/plugins/console.ts
+++ b/packages/page-spy-mp-base/src/plugins/console.ts
@@ -71,8 +71,11 @@ export default class ConsolePlugin implements PageSpyPlugin {
 
   public printLog(data: SpyConsole.DataItem) {
     if (data.logs && data.logs.length) {
-      this.console[data.logType](...data.logs);
+      const processedByUser =
+        this.$pageSpyConfig?.dataProcessor?.console?.(data);
+      if (processedByUser === false) return;
 
+      this.console[data.logType](...data.logs);
       const atomLog = makeMessage('console', {
         ...data,
         time: Date.now(),

--- a/packages/page-spy-mp-base/src/plugins/console.ts
+++ b/packages/page-spy-mp-base/src/plugins/console.ts
@@ -30,8 +30,12 @@ export default class ConsolePlugin implements PageSpyPlugin {
     if (ConsolePlugin.hasInitd) return;
     ConsolePlugin.hasInitd = true;
 
-    const that = this;
     this.$pageSpyConfig = config;
+    this.init();
+  }
+
+  public init() {
+    const that = this;
     this.proxyTypes.forEach((item) => {
       // Not using globalThis or global, cause "console" exists in any env,
       // but global may be blocked.
@@ -59,21 +63,30 @@ export default class ConsolePlugin implements PageSpyPlugin {
     });
   }
 
-  public onReset() {
+  public reset() {
     this.proxyTypes.forEach((item) => {
       const originFn = this.console[item];
       if (originFn) {
         console[item] = originFn;
       }
     });
+  }
+
+  public onReset() {
+    this.reset();
     ConsolePlugin.hasInitd = false;
   }
 
   public printLog(data: SpyConsole.DataItem) {
     if (data.logs && data.logs.length) {
-      const processedByUser =
-        this.$pageSpyConfig?.dataProcessor?.console?.(data);
-      if (processedByUser === false) return;
+      const processor = this.$pageSpyConfig?.dataProcessor?.console;
+      if (processor) {
+        this.reset();
+        const processedByUser = processor(data);
+        this.init();
+
+        if (processedByUser === false) return;
+      }
 
       this.console[data.logType](...data.logs);
       const atomLog = makeMessage('console', {

--- a/packages/page-spy-mp-base/src/plugins/error.ts
+++ b/packages/page-spy-mp-base/src/plugins/error.ts
@@ -2,6 +2,8 @@ import { atom, makeMessage, formatErrorObj } from '@huolala-tech/page-spy-base';
 import type {
   SpyConsole,
   PageSpyPlugin,
+  SpyMP,
+  OnInitParams,
 } from '@huolala-tech/page-spy-types/index';
 import socketStore from '../helpers/socket';
 import { getMPSDK } from '../utils';
@@ -12,10 +14,13 @@ export default class ErrorPlugin implements PageSpyPlugin {
 
   public static hasInitd = false;
 
-  public onInit() {
+  public $pageSpyConfig: SpyMP.MPInitConfig | null = null;
+
+  public onInit({ config }: OnInitParams<SpyMP.MPInitConfig>) {
     if (ErrorPlugin.hasInitd) return;
     ErrorPlugin.hasInitd = true;
 
+    this.$pageSpyConfig = config;
     this.onUncaughtError();
     this.onUnhandledRejectionError();
   }
@@ -38,13 +43,13 @@ export default class ErrorPlugin implements PageSpyPlugin {
     if (error.stack || error.message) {
       /* c8 ignore start */
       const { message, stack } = error;
-      ErrorPlugin.sendMessage(stack || message, formatErrorObj(error));
+      this.sendMessage(stack || message, formatErrorObj(error));
       /* c8 ignore stop */
     } else {
       // When the error does not exist, use default information
       const defaultMessage =
         '[PageSpy] An unknown error occurred and no message or stack trace available';
-      ErrorPlugin.sendMessage(defaultMessage, null);
+      this.sendMessage(defaultMessage, null);
     }
   }
 
@@ -52,7 +57,7 @@ export default class ErrorPlugin implements PageSpyPlugin {
     if (!ErrorPlugin.hasInitd) {
       return;
     }
-    ErrorPlugin.sendMessage('UnHandled Rejection', {
+    this.sendMessage('UnHandled Rejection', {
       name: 'unhandledrejection',
       message: evt.reason,
     });
@@ -73,19 +78,25 @@ export default class ErrorPlugin implements PageSpyPlugin {
     }
   }
 
-  public static sendMessage(
+  public sendMessage(
     data: any,
     errorDetail: SpyConsole.DataItem['errorDetail'] | null,
   ) {
     // Treat `error` data as `console`
     const error = {
       logType: 'error',
-      logs: [atom.transformToAtom(data)],
+      logs: [data],
       time: Date.now(),
       // TODO: more mp types
       url: 'wx:light-app', // window.location.href,
       errorDetail,
     };
+    const processedByUser = this.$pageSpyConfig?.dataProcessor?.console?.(
+      error as SpyConsole.DataItem,
+    );
+    if (processedByUser === false) return;
+
+    error.logs = error.logs.map((l) => atom.transformToAtom(l));
     const message = makeMessage('console', error);
     socketStore.dispatchEvent('public-data', message);
     socketStore.broadcastMessage(message);

--- a/packages/page-spy-mp-base/src/plugins/error.ts
+++ b/packages/page-spy-mp-base/src/plugins/error.ts
@@ -14,6 +14,11 @@ export default class ErrorPlugin implements PageSpyPlugin {
 
   public static hasInitd = false;
 
+  constructor() {
+    this.errorHandler = this.errorHandler.bind(this);
+    this.unhandledRejectionHandler = this.unhandledRejectionHandler.bind(this);
+  }
+
   public $pageSpyConfig: SpyMP.MPInitConfig | null = null;
 
   public onInit({ config }: OnInitParams<SpyMP.MPInitConfig>) {

--- a/packages/page-spy-mp-base/src/plugins/network/index.ts
+++ b/packages/page-spy-mp-base/src/plugins/network/index.ts
@@ -1,5 +1,10 @@
 // eslint-disable no-case-declarations
-import type { PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import type {
+  OnInitParams,
+  PageSpyPlugin,
+  SpyMP,
+} from '@huolala-tech/page-spy-types';
+import { NetworkProxyBase } from '@huolala-tech/page-spy-base';
 import RequestProxy from './proxy/request';
 
 export default class NetworkPlugin implements PageSpyPlugin {
@@ -9,9 +14,10 @@ export default class NetworkPlugin implements PageSpyPlugin {
 
   public static hasInitd = false;
 
-  public onInit() {
+  public onInit({ config }: OnInitParams<SpyMP.MPInitConfig>) {
     if (NetworkPlugin.hasInitd) return;
     NetworkPlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
 
     this.requestProxy = new RequestProxy();
   }

--- a/packages/page-spy-mp-base/tests/plugins/error.test.ts
+++ b/packages/page-spy-mp-base/tests/plugins/error.test.ts
@@ -1,13 +1,22 @@
 import ErrorPlugin from 'page-spy-mp-base/src/plugins/error';
 import { mp } from '../setup';
+import { OnInitParams, SpyMP } from 'packages/page-spy-types';
+import { Config } from 'page-spy-mp-base/src/config';
+import socket from 'page-spy-mp-base/src/helpers/socket';
+import { atom } from 'page-spy-base/src';
 
+const initParams = {
+  config: new Config().mergeConfig({ api: 'example.com' }),
+  socketStore: socket,
+  atom,
+} as OnInitParams<SpyMP.MPInitConfig>;
 const plugin = new ErrorPlugin();
 
 beforeEach(() => {
-  plugin.onInit();
+  plugin.onInit(initParams);
 });
 
-const errorOccupied = jest.spyOn(ErrorPlugin, 'sendMessage');
+const errorOccupied = jest.spyOn(ErrorPlugin.prototype, 'sendMessage');
 afterEach(() => {
   errorOccupied.mockClear();
   plugin.onReset();

--- a/packages/page-spy-mp-base/tests/plugins/network.test.ts
+++ b/packages/page-spy-mp-base/tests/plugins/network.test.ts
@@ -1,7 +1,16 @@
 import NetworkPlugin from 'page-spy-mp-base/src/plugins/network';
 import { computeRequestMapInfo } from './util';
 import { mp } from '../setup';
+import { OnInitParams, SpyMP } from 'packages/page-spy-types';
+import { atom } from 'page-spy-base/src';
+import { Config } from 'page-spy-mp-base/src/config';
+import socket from 'page-spy-mp-base/src/helpers/socket';
 
+const initParams = {
+  config: new Config().mergeConfig({ api: 'example.com' }),
+  socketStore: socket,
+  atom,
+} as OnInitParams<SpyMP.MPInitConfig>;
 const port = 6688;
 const apiPrefix = `http://localhost:${port}`;
 // const stopServer = startServer(port);
@@ -24,20 +33,20 @@ describe('mp.request proxy', () => {
       value: undefined,
       writable: true,
     });
-    plugin.onInit();
+    plugin.onInit(initParams);
     expect(mp.request).toBe(undefined);
   });
   it('Wrap mp request', () => {
     const reqSpy = jest.spyOn(mp, 'request');
     expect(mp.request).toBe(reqSpy);
 
-    plugin.onInit();
+    plugin.onInit(initParams);
     expect(mp.request).not.toBe(reqSpy);
   });
 
   it('The origin request will be called and get response', (done) => {
     const reqSpy = jest.spyOn(mp, 'request');
-    plugin.onInit();
+    plugin.onInit(initParams);
 
     // fetch(url, init)
     const url = `/`;
@@ -53,7 +62,7 @@ describe('mp.request proxy', () => {
 
   it('The origin callback will be called', async () => {
     const reqSpy = jest.spyOn(mp, 'request');
-    plugin.onInit();
+    plugin.onInit(initParams);
 
     const successCallback = jest.fn();
     const completeCallback = jest.fn();
@@ -81,7 +90,7 @@ describe('mp.request proxy', () => {
   });
 
   it('Request plain text', (done) => {
-    plugin.onInit();
+    plugin.onInit(initParams);
     mp.request({
       url: '/plain-text',
       success(res) {
@@ -114,7 +123,7 @@ describe('mp.request proxy', () => {
   });
 
   it('Array buffer response will not be converted to base64', (done) => {
-    plugin.onInit();
+    plugin.onInit(initParams);
     const { requestProxy } = plugin;
     expect(computeRequestMapInfo(requestProxy).size).toBe(0);
 
@@ -134,7 +143,7 @@ describe('mp.request proxy', () => {
   });
 
   it('The SDK record the request information', () => {
-    plugin.onInit();
+    plugin.onInit(initParams);
     const { requestProxy } = plugin;
     expect(requestProxy).not.toBe(null);
     expect(computeRequestMapInfo(requestProxy).size).toBe(0);

--- a/packages/page-spy-mp-base/tests/plugins/storage.test.ts
+++ b/packages/page-spy-mp-base/tests/plugins/storage.test.ts
@@ -3,11 +3,19 @@ import StoragePlugin, {
 } from 'page-spy-mp-base/src/plugins/storage';
 import { initStorageMock } from '../mock/storage';
 import { mp } from '../setup';
+import { OnInitParams, SpyMP } from 'packages/page-spy-types';
+import { atom } from 'page-spy-base/src';
+import { Config } from 'page-spy-mp-base/src/config';
+import socket from 'page-spy-mp-base/src/helpers/socket';
 
+const initParams = {
+  config: new Config().mergeConfig({ api: 'example.com' }),
+  socketStore: socket,
+  atom,
+} as OnInitParams<SpyMP.MPInitConfig>;
 const sleep = (t = 100) => new Promise((r) => setTimeout(r, t));
 
-// @ts-ignore
-const trigger = jest.spyOn(StoragePlugin, 'sendStorageItem');
+const trigger = jest.spyOn(StoragePlugin.prototype, 'sendStorageItem');
 
 const plugin = new StoragePlugin();
 
@@ -15,7 +23,7 @@ beforeAll(() => {
   initStorageMock();
 });
 beforeEach(() => {
-  plugin.onInit();
+  plugin.onInit(initParams);
 });
 afterEach(() => {
   trigger.mockReset();
@@ -111,7 +119,7 @@ describe('Storage plugin', () => {
   });
 
   it('Send refresh all storage', async () => {
-    StoragePlugin.sendRefresh();
+    plugin.sendRefresh();
     expect(trigger).toHaveBeenCalledTimes(1);
     expect(trigger).lastCalledWith(
       expect.objectContaining({

--- a/packages/page-spy-react-native/src/config.ts
+++ b/packages/page-spy-react-native/src/config.ts
@@ -18,7 +18,6 @@ export class Config extends ConfigBase<InitConfig> {
   protected privateKeys: (keyof InitConfig)[] = ['secret'];
 
   // I need to use generic type on this method, so it can't be static
-  /* eslint-disable-next-line class-methods-use-this */
   protected defaultConfig() {
     return {
       api: '',
@@ -30,6 +29,7 @@ export class Config extends ConfigBase<InitConfig> {
       secret: '',
       messageCapacity: 0,
       serializeData: false,
+      dataProcessor: {},
     };
   }
 }

--- a/packages/page-spy-react-native/src/plugins/console.ts
+++ b/packages/page-spy-react-native/src/plugins/console.ts
@@ -28,8 +28,12 @@ export default class ConsolePlugin implements PageSpyPlugin {
     if (ConsolePlugin.hasInitd) return;
     ConsolePlugin.hasInitd = true;
 
-    const that = this;
     this.$pageSpyConfig = config;
+    this.init();
+  }
+
+  public init() {
+    const that = this;
     this.proxyTypes.forEach((item) => {
       // Not using globalThis or global, cause "console" exists in any env,
       // but global may be blocked.
@@ -49,18 +53,27 @@ export default class ConsolePlugin implements PageSpyPlugin {
     });
   }
 
-  public onReset() {
+  public reset() {
     this.proxyTypes.forEach((item) => {
       console[item] = this.console[item];
     });
+  }
+
+  public onReset() {
+    this.reset();
     ConsolePlugin.hasInitd = false;
   }
 
   public printLog(data: SpyConsole.DataItem) {
     if (data.logs && data.logs.length) {
-      const processedByUser =
-        this.$pageSpyConfig?.dataProcessor?.console?.(data);
-      if (processedByUser === false) return;
+      const processor = this.$pageSpyConfig?.dataProcessor?.console;
+      if (processor) {
+        this.reset();
+        const processedByUser = processor(data);
+        this.init();
+
+        if (processedByUser === false) return;
+      }
 
       this.console[data.logType](...data.logs);
       const atomLog = makeMessage('console', {

--- a/packages/page-spy-react-native/src/plugins/console.ts
+++ b/packages/page-spy-react-native/src/plugins/console.ts
@@ -58,8 +58,11 @@ export default class ConsolePlugin implements PageSpyPlugin {
 
   public printLog(data: SpyConsole.DataItem) {
     if (data.logs && data.logs.length) {
-      this.console[data.logType](...data.logs);
+      const processedByUser =
+        this.$pageSpyConfig?.dataProcessor?.console?.(data);
+      if (processedByUser === false) return;
 
+      this.console[data.logType](...data.logs);
       const atomLog = makeMessage('console', {
         ...data,
         time: Date.now(),

--- a/packages/page-spy-react-native/src/plugins/network/index.ts
+++ b/packages/page-spy-react-native/src/plugins/network/index.ts
@@ -1,19 +1,23 @@
 // eslint-disable no-case-declarations
-import type { PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import type { OnInitParams, PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import { NetworkProxyBase } from '@huolala-tech/page-spy-base';
 import XhrProxy from './proxy/xhr-proxy';
 import FetchProxy from './proxy/fetch-proxy';
+import { InitConfig } from '../../config';
 
 export default class NetworkPlugin implements PageSpyPlugin {
   public name = 'NetworkPlugin';
 
   public xhrProxy: XhrProxy | null = null;
+
   public fetchProxy: FetchProxy | null = null;
 
   public static hasInitd = false;
 
-  public onInit() {
+  public onInit({ config }: OnInitParams<InitConfig>) {
     if (NetworkPlugin.hasInitd) return;
     NetworkPlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
 
     this.fetchProxy = new FetchProxy();
     this.xhrProxy = new XhrProxy();

--- a/packages/page-spy-types/lib/index.d.ts
+++ b/packages/page-spy-types/lib/index.d.ts
@@ -1,6 +1,10 @@
+import { RequestItem } from '@huolala-tech/page-spy-base';
 import { SocketStoreType } from './base';
 import { DataItem as ConsoleData } from './console';
 import { DataItem as StorageData } from './storage';
+import { DataItem as PageData } from './page';
+import { DataItem as DatabaseData } from './database';
+import { DataItem as SystemData } from './system';
 
 export interface InitConfigBase {
   /**
@@ -64,8 +68,11 @@ export interface InitConfigBase {
    */
   dataProcessor?: {
     console?: (data: ConsoleData) => boolean;
-    network?: (data: RequestInfo) => boolean;
+    network?: (data: RequestItem) => boolean;
     storage?: (data: StorageData) => boolean;
+    database?: (data: DatabaseData) => boolean;
+    page?: (data: PageData) => boolean;
+    system?: (data: SystemData) => boolean;
   };
 
   [key: string]: any;

--- a/packages/page-spy-types/lib/index.d.ts
+++ b/packages/page-spy-types/lib/index.d.ts
@@ -1,4 +1,6 @@
 import { SocketStoreType } from './base';
+import { DataItem as ConsoleData } from './console';
+import { DataItem as StorageData } from './storage';
 
 export interface InitConfigBase {
   /**
@@ -53,9 +55,18 @@ export interface InitConfigBase {
   secret?: string;
 
   /**
-   *
+   * Indicate whether serialize non-primitive data in offline log.
    */
   serializeData?: boolean;
+
+  /**
+   *
+   */
+  dataProcessor?: {
+    console?: (data: ConsoleData) => boolean;
+    network?: (data: RequestInfo) => boolean;
+    storage?: (data: StorageData) => boolean;
+  };
 
   [key: string]: any;
 }

--- a/packages/page-spy-types/lib/index.d.ts
+++ b/packages/page-spy-types/lib/index.d.ts
@@ -1,10 +1,10 @@
-import { RequestItem } from '@huolala-tech/page-spy-base';
 import { SocketStoreType } from './base';
 import { DataItem as ConsoleData } from './console';
 import { DataItem as StorageData } from './storage';
 import { DataItem as PageData } from './page';
 import { DataItem as DatabaseData } from './database';
 import { DataItem as SystemData } from './system';
+import { RequestInfo } from './network';
 
 export interface InitConfigBase {
   /**
@@ -68,7 +68,7 @@ export interface InitConfigBase {
    */
   dataProcessor?: {
     console?: (data: ConsoleData) => boolean;
-    network?: (data: RequestItem) => boolean;
+    network?: (data: RequestInfo) => boolean;
     storage?: (data: StorageData) => boolean;
     database?: (data: DatabaseData) => boolean;
     page?: (data: PageData) => boolean;

--- a/packages/page-spy-types/lib/page.d.ts
+++ b/packages/page-spy-types/lib/page.d.ts
@@ -1,4 +1,4 @@
 export interface DataItem {
   html: string;
-  location: Record<keyof Location, string>;
+  location: Location;
 }


### PR DESCRIPTION
## 背景

一些用户希望修改或者定制化 PageSpy 插件产生的数据。例如：

- 网络请求多媒体资源，用户不关心响应数据 https://github.com/HuolalaTech/page-spy-web/issues/250 ；
- 生产环境发出的数据监控、埋点类的网络请求用户不关心；
- 控制 Console 打印信息；
  <img src="https://github.com/user-attachments/assets/f09436aa-dcf4-429c-89a1-86bffa4c7f48" width="300" />


这个 PR 就是去解决上述需求的。

## 使用

```ts
new PageSpy({
  ...,
  dataProcessor?: {
    console?: (data: ConsoleData) => boolean;
    network?: (data: RequestItem) => boolean;
    storage?: (data: StorageData) => boolean;
    database?: (data: DatabaseData) => boolean;
    page?: (data: PageData) => boolean;
    system?: (data: SystemData) => boolean;
  };
}) 
```

处理函数分别对应各个内置的插件，用户可以在函数中直接修改数据，函数执行完成后 PageSpy 处理修改后的数据。如果函数返回 `false`，PageSpy 会 **忽略掉该条数据**：这意味着在两种模式下的调试端都不会看到这条数据。

## 示例

```ts
window.$pageSpy = new PageSpy({
  ...,
  dataProcessor: {
    console: (data) => {
      // 打印内容中如果有 "secret" 字符，忽略
      if (data.logs.some(i => typeof i === 'string' && i.includes('secret'))) return false;
    },
    network: (data) => {
      // 忽略数据打点类的请求
      if (/(sentry|metric|collect)/.test(data.url)) return false
    },,
    storage: (data) => {
      // cookie 中的键如果是下划线开头，让调试端看到的值为 "*******"
      if (data.type === "cookie" && data.action === "get") {
        data.data.forEach((i) => {
          if (i.name.startsWith("_")) {
            i.value = "*******";
          }
        });
      }
    },
  },
});
```
