### PR TITLE
fix: react-native don't support global and Document

### DIFF
--- a/packages/page-spy-base/src/utils.ts
+++ b/packages/page-spy-base/src/utils.ts
@@ -106,7 +106,7 @@ export function isHeaders(value: unknown): value is Headers {
 }
 
 export function isDocument(value: unknown): value is Document {
-  return value instanceof Document;
+  return typeof globalThis.Document !== 'undefined' && value instanceof globalThis.Document;
 }
 
 export function isURL(value: unknown): value is URL {

--- a/packages/page-spy-react-native/src/plugins/error.ts
+++ b/packages/page-spy-react-native/src/plugins/error.ts
@@ -52,8 +52,8 @@ export default class ErrorPlugin implements PageSpyPlugin {
       return;
     }
     // @ts-ignore
-    this.originPromise = global.Promise;
-    global.Promise = LocalPromise;
+    this.originPromise = globalThis.Promise;
+    globalThis.Promise = LocalPromise;
     RejectTracking.enable({
       allRejections: true,
       onUnhandled: (id: any, error: any) => {

--- a/packages/page-spy-react-native/src/utils.ts
+++ b/packages/page-spy-react-native/src/utils.ts
@@ -20,8 +20,8 @@ export const getGlobal = () => {
     foundGlobal = globalThis;
   } else if (typeof window !== 'undefined') {
     foundGlobal = window;
-  } else if (typeof global === 'object' && Object.keys(global).length > 1) {
-    foundGlobal = global;
+  } else if (typeof globalThis === 'object' && Object.keys(globalThis).length > 1) {
+    foundGlobal = globalThis;
   }
   if (customGlobal) {
     Object.assign(foundGlobal, customGlobal);


### PR DESCRIPTION
# Issue
React Native was unable to successfully integrate with the SDK due to a lack of platform compatibility code when writing the base SDK.

# Link 
- https://github.com/HuolalaTech/page-spy-web/issues/269 (Last time, I mistakenly submitted the issue to another warehouse)
