### PR TITLE
feat: support custom behavior after harbor upload

### DIFF
--- a/packages/page-spy-plugin-data-harbor/src/index.ts
+++ b/packages/page-spy-plugin-data-harbor/src/index.ts
@@ -46,7 +46,10 @@ interface DataHarborConfig {
   filename?: () => string;
 
   // Custom download behavior.
-  onDownload?: ((data: CacheMessageItem[]) => void) | null;
+  onDownload?: (data: CacheMessageItem[]) => void;
+
+  // Custom behavior after upload.
+  onAfterUpload?: (replayUrl: string) => void;
 }
 
 const defaultConfig: Required<DataHarborConfig> = {
@@ -61,7 +64,8 @@ const defaultConfig: Required<DataHarborConfig> = {
   filename: () => {
     return new Date().toLocaleString();
   },
-  onDownload: null,
+  onDownload: () => {},
+  onAfterUpload: () => {},
 };
 
 export default class DataHarborPlugin implements PageSpyPlugin {
@@ -285,7 +289,9 @@ export default class DataHarborPlugin implements PageSpyPlugin {
     }
 
     if (result) {
-      return this.getDebugUrl(result);
+      const url = this.getDebugUrl(result);
+      this.$harborConfig.onAfterUpload(url);
+      return url;
     }
   }
 


### PR DESCRIPTION
## Changes

- `DataHarborPlugin` 允许用户自定义上传后的回调，比如测试上传后、开发收到通知。

## Related

- https://github.com/HuolalaTech/page-spy-web/issues/252