### PR TITLE
小程序 data-harbor 使用 json 上传离线日志

### DIFF
--- a/packages/page-spy-plugin-mp-data-harbor/src/index.ts
+++ b/packages/page-spy-plugin-mp-data-harbor/src/index.ts
@@ -16,10 +16,10 @@ import { MemoryHarbor } from './harbor/memoryHarbor';
 import { saveData } from './utils/upload';
 import {
   buildSearchParams,
+  formatFilename,
   getDeviceId,
   getMPSDK,
   makeData,
-  makeFile,
   setMPSDK,
 } from './utils';
 import { DataType, WholeActionParams } from './harbor/base';
@@ -45,8 +45,7 @@ const defaultConfig: DataHarborConfig = {
     meta: true,
   },
   filename: () => {
-    const d = new Date();
-    return `${d.getFullYear()}_${d.getMonth() + 1}_${d.getDate()}_${d.getHours()}_${d.getMinutes()}_${d.getSeconds()}`;
+    return new Date().toLocaleString();
   },
   onAfterUpload: () => {},
 };
@@ -171,7 +170,7 @@ export default class MPDataHarborPlugin implements PageSpyPlugin {
       // userAgent: navigator.userAgent,
       userAgent: this.client?.getName(),
       remark: params?.remark || '',
-      name: filename() + '.json',
+      name: formatFilename(filename()) + '.json',
     };
     const data = [...this.harbor.container];
     data.push(this.makeMetaInfo());

--- a/packages/page-spy-plugin-mp-data-harbor/src/index.ts
+++ b/packages/page-spy-plugin-mp-data-harbor/src/index.ts
@@ -29,7 +29,7 @@ interface DataHarborConfig {
   caredData?: Record<DataType, boolean>;
 
   // Custom uploaded filename by this.
-  // Default value is `new Date().toLocaleString()`.
+  // Default value is a date time string.
   filename?: () => string;
 
   // Custom behavior after upload
@@ -46,7 +46,7 @@ const defaultConfig: DataHarborConfig = {
   },
   filename: () => {
     const d = new Date();
-    return `${d.getFullYear()}_${d.getMonth() + 1}_${d.getDate()}_${d.getHours()}_${d.getMinutes()}_${d.getSeconds()}.json`;
+    return `${d.getFullYear()}_${d.getMonth() + 1}_${d.getDate()}_${d.getHours()}_${d.getMinutes()}_${d.getSeconds()}`;
   },
   onAfterUpload: () => {},
 };
@@ -171,7 +171,7 @@ export default class MPDataHarborPlugin implements PageSpyPlugin {
       // userAgent: navigator.userAgent,
       userAgent: this.client?.getName(),
       remark: params?.remark || '',
-      name: filename(),
+      name: filename() + '.json',
     };
     const data = [...this.harbor.container];
     data.push(this.makeMetaInfo());

--- a/packages/page-spy-plugin-mp-data-harbor/src/utils/index.ts
+++ b/packages/page-spy-plugin-mp-data-harbor/src/utils/index.ts
@@ -29,14 +29,6 @@ export const makeData = <T extends SpyMessage.DataType>(type: T, data: any) => {
   };
 };
 
-// in mini program, it's unable to make file in memory using blob, need to save file to disk.
-export const makeFile = (data: any, filename: string) => {
-  const fs = mp.getFileSystemManager();
-  const path = `${mp.env.USER_DATA_PATH}/${formatFilename(filename)}.json`;
-  fs.writeFileSync(path, JSON.stringify(data), 'utf8');
-  return path;
-};
-
 export const buildSearchParams = (obj: Record<string, any>) => {
   return Object.entries(obj)
     .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)

--- a/packages/page-spy-plugin-mp-data-harbor/src/utils/upload.ts
+++ b/packages/page-spy-plugin-mp-data-harbor/src/utils/upload.ts
@@ -3,24 +3,19 @@ import { getMPSDK } from '.';
 
 export type UploadArgs = {
   url: string;
-  path: string;
+  data: any;
 };
 
-declare var uni: any;
-
-export const startUpload = async ({ url, path }: UploadArgs) => {
+export const saveData = async ({ url, data }: UploadArgs) => {
   return new Promise<H.UploadResult>((resolve, reject) => {
     const mp = getMPSDK();
-    mp.uploadFile({
-      filePath: path,
-      header: {
-        'Content-Type': 'multipart/form-data',
-      },
-      name: 'log',
+    mp.request({
+      data,
       url,
+      method: 'POST',
       success: (res: any) => {
         if (res.statusCode === 200) {
-          const data = JSON.parse(res.data);
+          const data = res.data;
           if (data.success) {
             resolve(data);
           } else {


### PR DESCRIPTION
原有的上传日志方式需要本地造文件，而小程序环境差异大，需要多种兼容，改成 json 接口形式比较方便。
