### PR TITLE
feat: add Translation class in base and add support lang param

### DIFF
--- a/packages/page-spy-base/src/index.ts
+++ b/packages/page-spy-base/src/index.ts
@@ -9,3 +9,4 @@ export * from './constants';
 export * from './request-item';
 export * from './socket-base';
 export * from './utils';
+export * from './translation';

--- a/packages/page-spy-base/src/translation.ts
+++ b/packages/page-spy-base/src/translation.ts
@@ -1,0 +1,61 @@
+import { isCN, psLog } from './utils';
+
+export type Lang = 'zh' | 'en';
+export type Locales<T extends string> = Record<Lang, Record<T, string>>;
+
+interface TranslationOptions<T extends string> {
+  locales: Locales<T>;
+  defaultLang?: Lang;
+}
+
+const systemLang = isCN() ? 'zh' : 'en';
+
+export class Translation<T extends string> {
+  private locales: Locales<T>;
+
+  private currentLang: Lang;
+
+  constructor(options: TranslationOptions<T>) {
+    const { locales, defaultLang = systemLang } = options;
+
+    if (!locales || Object.keys(locales).length === 0) {
+      throw new Error('[PageSpy] Locales cannot be empty');
+    }
+
+    if (!locales[defaultLang]) {
+      throw new Error(`[PageSpy] Language "${defaultLang}" not found`);
+    }
+
+    this.locales = locales;
+    this.currentLang = defaultLang;
+  }
+
+  // key 的类型变为 T，提供具体键名提示
+  t(key: T, lang?: Lang): string {
+    const targetLang = lang || this.currentLang;
+    const locale = this.locales[targetLang];
+
+    if (!locale) {
+      psLog.warn(`Language '${targetLang}' not found, falling back to default`);
+      return key;
+    }
+
+    return locale[key] || key;
+  }
+
+  setLang(lang: Lang): void {
+    if (!this.locales[lang]) {
+      psLog.error(`Language '${lang}' is not supported`);
+      return;
+    }
+    this.currentLang = lang;
+  }
+
+  getCurrentLang(): string {
+    return this.currentLang;
+  }
+
+  getSupportedLangs(): string[] {
+    return Object.keys(this.locales);
+  }
+}

--- a/packages/page-spy-base/src/utils.ts
+++ b/packages/page-spy-base/src/utils.ts
@@ -117,11 +117,12 @@ export function isClass(obj: unknown): obj is Function {
   return typeof obj === 'function' && typeof obj.prototype !== 'undefined';
 }
 
+const CN_IDs = ['zh-CN', 'zh-HK', 'zh-TW', 'zh', 'zh-Hans-CN'];
 export function isCN() {
-  const langs = navigator.languages;
-  return ['zh-CN', 'zh-HK', 'zh-TW', 'zh', 'zh-Hans-CN'].some((l) => {
-    return langs.includes(l);
-  });
+  const lang = document?.documentElement.lang;
+  if (lang) return CN_IDs.some((i) => i === lang);
+
+  return CN_IDs.some((i) => i === navigator?.language);
 }
 
 type TypedArray =

--- a/packages/page-spy-base/src/utils.ts
+++ b/packages/page-spy-base/src/utils.ts
@@ -119,10 +119,13 @@ export function isClass(obj: unknown): obj is Function {
 
 const CN_IDs = ['zh-CN', 'zh-HK', 'zh-TW', 'zh', 'zh-Hans-CN'];
 export function isCN() {
-  const lang = document?.documentElement.lang;
-  if (lang) return CN_IDs.some((i) => i === lang);
+  if (isBrowser()) {
+    const { lang } = document.documentElement;
+    if (lang) return CN_IDs.some((i) => i === lang);
 
-  return CN_IDs.some((i) => i === navigator?.language);
+    return CN_IDs.some((i) => i === navigator.language);
+  }
+  return false;
 }
 
 type TypedArray =

--- a/packages/page-spy-browser/src/assets/locales.ts
+++ b/packages/page-spy-browser/src/assets/locales.ts
@@ -1,6 +1,6 @@
-import { isCN } from '@huolala-tech/page-spy-base';
+import { Translation } from '@huolala-tech/page-spy-base';
 
-const source = {
+const locales = {
   zh: {
     copyLink: '复制在线调试链接',
     copied: '复制成功',
@@ -13,6 +13,6 @@ const source = {
   },
 };
 
-const locales = isCN() ? source.zh : source.en;
-
-export default locales;
+export const i18n = new Translation({
+  locales,
+});

--- a/packages/page-spy-browser/src/config.ts
+++ b/packages/page-spy-browser/src/config.ts
@@ -1,4 +1,4 @@
-import { ConfigBase } from '@huolala-tech/page-spy-base';
+import { ConfigBase, Lang } from '@huolala-tech/page-spy-base';
 import { InitConfigBase } from '@huolala-tech/page-spy-types';
 import type { Command } from 'iseedeadpeople/dist/common';
 import logoUrl from './assets/logo.svg';
@@ -64,6 +64,10 @@ export interface InitConfig extends InitConfigBase {
    * The size of `Command` must be at least 4.
    */
   gesture?: Command | null;
+  /**
+   * Specify language
+   */
+  lang?: Lang | null;
 }
 
 export class Config extends ConfigBase<InitConfig> {
@@ -97,6 +101,7 @@ export class Config extends ConfigBase<InitConfig> {
         title: 'PageSpy',
       },
       gesture: null,
+      lang: null,
     };
 
     if (!Config.scriptLink) {

--- a/packages/page-spy-browser/src/index.ts
+++ b/packages/page-spy-browser/src/index.ts
@@ -32,12 +32,12 @@ import type { UElement } from './helpers/moveable';
 import { moveable } from './helpers/moveable';
 import { Config, nodeId } from './config';
 import { toast } from './helpers/toast';
-import locales from './assets/locales';
 import modalLogoSvg from './assets/modal-logo.svg';
 import copySvg from './assets/copy.svg';
 import { modal } from './helpers/modal';
 import classes from './assets/styles/index.module.less';
 import { version } from '../package.json';
+import { i18n } from './assets/locales';
 
 type UpdateConfig = {
   title?: string;
@@ -136,25 +136,13 @@ class PageSpy {
     }
   }
 
-  private updateConfiguration() {
-    const { messageCapacity, offline, useSecret } = this.config.get();
-    if (useSecret === true) {
-      const cache = JSON.parse(
-        sessionStorage.getItem(ROOM_SESSION_KEY) as string,
-      );
-      this.config.set('secret', cache?.secret || getAuthSecret());
-    }
-    socketStore.connectable = true;
-    socketStore.getPageSpyConfig = () => this.config.get();
-    socketStore.getClient = () => PageSpy.client;
-    socketStore.isOffline = offline;
-    socketStore.messageCapacity = messageCapacity;
-  }
-
   private async init(ic: InitConfig) {
     PageSpy.instance = this;
 
     const config = this.config.mergeConfig(ic);
+    if (config.lang) {
+      i18n.setLang(config.lang);
+    }
     this.updateConfiguration();
     this.triggerPlugins('onInit', { config, socketStore });
 
@@ -183,6 +171,21 @@ class PageSpy {
     if (config.autoRender) {
       this.render();
     }
+  }
+
+  private updateConfiguration() {
+    const { messageCapacity, offline, useSecret } = this.config.get();
+    if (useSecret === true) {
+      const cache = JSON.parse(
+        sessionStorage.getItem(ROOM_SESSION_KEY) as string,
+      );
+      this.config.set('secret', cache?.secret || getAuthSecret());
+    }
+    socketStore.connectable = true;
+    socketStore.getPageSpyConfig = () => this.config.get();
+    socketStore.getClient = () => PageSpy.client;
+    socketStore.isOffline = offline;
+    socketStore.messageCapacity = messageCapacity;
   }
 
   private cacheIsInvalid() {
@@ -362,7 +365,7 @@ class PageSpy {
       <!-- Default button for modal -->
       <button class="page-spy-btn" data-primary id="page-spy-copy-link">
         <img src="${copySvg}" alt="Copy" />
-        <span>${locales.copyLink}</span>
+        <span>${i18n.t('copyLink')}</span>
       </button>
     `,
       'text/html',
@@ -401,7 +404,7 @@ class PageSpy {
         text += `&secret=${secret}`;
       }
       const copied = copy(text);
-      const message = copied ? locales.copied : locales.copyFailed;
+      const message = copied ? i18n.t('copied') : i18n.t('copyFailed');
       modal.close();
       toast.message(message);
     });

--- a/packages/page-spy-plugin-data-harbor/src/assets/locale.ts
+++ b/packages/page-spy-plugin-data-harbor/src/assets/locale.ts
@@ -1,6 +1,6 @@
-import { isCN } from '@huolala-tech/page-spy-base/dist/utils';
+import { Translation } from '@huolala-tech/page-spy-base';
 
-const source = {
+const locales = {
   zh: {
     title: '离线日志',
     uploadPeriods: '上传时间段',
@@ -52,4 +52,6 @@ const source = {
   },
 };
 
-export const t = isCN() ? source.zh : source.en;
+export const i18n = new Translation({
+  locales,
+});

--- a/packages/page-spy-plugin-data-harbor/src/harbor/blob.ts
+++ b/packages/page-spy-plugin-data-harbor/src/harbor/blob.ts
@@ -1,7 +1,7 @@
 import { isBrowser, isNumber } from '@huolala-tech/page-spy-base/dist/utils';
 import { isValidMaximum } from '../utils';
 import { CacheMessageItem, PeriodActionParams, PeriodItem } from './base';
-import { t } from '../assets/locale';
+import { i18n } from '../assets/locale';
 
 interface HarborConfig {
   maximum: number;
@@ -123,7 +123,7 @@ export class BlobHarbor {
       result = this.container.slice(fData, tData);
     } else {
       if (fStock === null) {
-        throw new Error(t.invalidPeriods);
+        throw new Error(i18n.t('invalidPeriods'));
       }
 
       // <stock> [

--- a/packages/page-spy-plugin-data-harbor/src/index.ts
+++ b/packages/page-spy-plugin-data-harbor/src/index.ts
@@ -31,7 +31,7 @@ import {
   WholeActionParams,
 } from './harbor/base';
 import { buildModal } from './utils/modal';
-import { t } from './assets/locale';
+import { i18n } from './assets/locale';
 
 interface DataHarborConfig {
   // Specify the maximum bytes of single harbor's container.
@@ -113,7 +113,10 @@ export default class DataHarborPlugin implements PageSpyPlugin {
     this.$pageSpyConfig = config;
     this.$socketStore = socketStore;
 
-    const { api, enableSSL, offline } = config;
+    const { api, enableSSL, offline, lang } = config;
+    if (lang) {
+      i18n.setLang(lang);
+    }
     if (!offline && !api) {
       psLog.warn(
         "Cannot upload log to PageSpy for miss 'api' configuration. See: ",
@@ -181,7 +184,7 @@ export default class DataHarborPlugin implements PageSpyPlugin {
     let data: CacheMessageItem[];
     if (isPeriodAction(type)) {
       if (!isPeriodActionParams(params) || params.startTime > params.endTime) {
-        throw new Error(t.invalidParams);
+        throw new Error(i18n.t('invalidParams'));
       }
       data = await this.harbor.getPeriodData(params);
 
@@ -196,7 +199,7 @@ export default class DataHarborPlugin implements PageSpyPlugin {
         (i) => i.timestamp >= validStartTime && i.timestamp <= params.endTime,
       ).length;
       if (validEventCount < 5) {
-        throw new Error(t.eventCountNotEnough);
+        throw new Error(i18n.t('eventCountNotEnough'));
       }
 
       data.push({

--- a/packages/page-spy-plugin-data-harbor/src/utils/log.ts
+++ b/packages/page-spy-plugin-data-harbor/src/utils/log.ts
@@ -1,6 +1,6 @@
 import { psLog } from '@huolala-tech/page-spy-base/dist/utils';
 import { CacheMessageItem } from '../harbor/base';
-import { t } from '../assets/locale';
+import { i18n } from '../assets/locale';
 import { formatFilename } from './index';
 
 export type UploadArgs = {
@@ -68,5 +68,5 @@ export const startDownload = async ({
   root.removeChild(a);
   URL.revokeObjectURL(url);
 
-  psLog.info(`${t.success}`);
+  psLog.info(`${i18n.t('success')}`);
 };

--- a/packages/page-spy-plugin-data-harbor/src/utils/modal.ts
+++ b/packages/page-spy-plugin-data-harbor/src/utils/modal.ts
@@ -10,7 +10,7 @@ import {
   successSvg,
   copySvg,
 } from '../assets/svg';
-import { t } from '../assets/locale';
+import { i18n } from '../assets/locale';
 import { PeriodItem } from '../harbor/base';
 import { formatTime } from './index';
 import type DataHarborPlugin from '../index';
@@ -33,7 +33,7 @@ export const buildModal = ({ plugin, modal, toast }: Params) => {
     <!-- Add button for default modal -->
     <button class="page-spy-btn" data-dashed id="open-log-action">
       ${cropSvg}
-      <span>${t.title}</span>
+      <span>${i18n.t('title')}</span>
     </button>
 
     <!-- Show modal content on button#open-log-action clicked -->
@@ -45,7 +45,7 @@ export const buildModal = ({ plugin, modal, toast }: Params) => {
       <div class="${classes.periodInfo}">
         <div class="${classes.label}">
           <div class="${classes.periodTips}">
-            <b>${t.selectPeriod}</b>
+            <b>${i18n.t('selectPeriod')}</b>
           </div>
           <button class="${classes.refreshButton}">${refreshSvg}</button>
         </div>
@@ -58,30 +58,30 @@ export const buildModal = ({ plugin, modal, toast }: Params) => {
         </div>
       </div>
       <div class="${classes.remarkInfo}">
-        <div class="${classes.label}">${t.remark}</div>
-        <textarea rows="5" id="harbor-remark" placeholder="${t.remarkPlaceholder}"></textarea>
+        <div class="${classes.label}">${i18n.t('remark')}</div>
+        <textarea rows="5" id="harbor-remark" placeholder="${i18n.t('remarkPlaceholder')}"></textarea>
       </div>
     </div>
 
     <!-- Upload / Download log button -->
     <button class="page-spy-btn" data-primary id="upload-periods">
       ${uploadPeriodsSvg}
-      <span>${t.uploadPeriods}</span>
+      <span>${i18n.t('uploadPeriods')}</span>
     </button>
     <button class="page-spy-btn" id="download-periods">
       ${downloadPeriodsSvg}
-      <span>${t.downloadPeriods}</span>
+      <span>${i18n.t('downloadPeriods')}</span>
     </button>
 
     <!-- Result -->
     <div class="${classes.result}">
       ${successSvg}
-      <b>${t.success}</b>
+      <b>${i18n.t('success')}</b>
     </div>
 
     <button class="page-spy-btn" data-primary id="copy-replay-url" data-url>
       ${copySvg}
-      <span>${t.copyUrl}</span>
+      <span>${i18n.t('copyUrl')}</span>
     </button>
     `,
     'text/html',
@@ -168,7 +168,7 @@ export const buildModal = ({ plugin, modal, toast }: Params) => {
   refreshButton.addEventListener('click', () => {
     refreshButton.disabled = true;
     refreshPeriods();
-    toast.message(t.refreshed);
+    toast.message(i18n.t('refreshed'));
     refreshButton.disabled = false;
   });
   minThumb.addEventListener('input', function () {
@@ -206,7 +206,7 @@ export const buildModal = ({ plugin, modal, toast }: Params) => {
   copyUrlButton.addEventListener('click', () => {
     const { url } = copyUrlButton.dataset;
     const ok = copy(url!);
-    toast.message(ok ? t.copied : t.copyFailed);
+    toast.message(ok ? i18n.t('copied') : i18n.t('copyFailed'));
     modal.close();
   });
   uploadPeriodsButton.addEventListener('click', async () => {
@@ -233,7 +233,7 @@ export const buildModal = ({ plugin, modal, toast }: Params) => {
     try {
       downloadPeriodsButton.disabled = true;
       await plugin.onOfflineLog('download-periods', getSelectedPeriod());
-      toast.message(t.success);
+      toast.message(i18n.t('success'));
     } catch (e: any) {
       psLog.error(e);
       toast.message(e.message);

--- a/packages/page-spy-plugin-ospy/index.html
+++ b/packages/page-spy-plugin-ospy/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html>
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -16,6 +16,7 @@
     <script type="module">
       import OSpy from './src';
       window.oSpy = new OSpy({
+        lang: 'zh',
         // autoRender: false,
         // primaryColor: 'darkgreen',
         // exportButtonText: '下载数据',

--- a/packages/page-spy-plugin-ospy/src/config.ts
+++ b/packages/page-spy-plugin-ospy/src/config.ts
@@ -1,8 +1,9 @@
 import { CacheMessageItem } from '@huolala-tech/page-spy-plugin-data-harbor/dist/types/harbor/base';
+import { Lang } from '@huolala-tech/page-spy-base';
 import pageSpyLogo from './assets/logo.svg';
-import { t } from './utils/locale';
 
 export interface Config {
+  lang: Lang | null;
   title: string;
   /**
    * Online source: 'https://example.com/xxx.jpg'
@@ -12,15 +13,16 @@ export interface Config {
   logo: string;
   primaryColor: string;
   autoRender: boolean;
-  exportButtonText: string;
+  exportButtonText: string | null;
   onExportButtonClick: ((data: CacheMessageItem[]) => void) | null;
 }
 
 export const defaultConfig: Config = {
+  lang: null,
   title: 'O-Spy',
   logo: pageSpyLogo,
   primaryColor: '#8434E9',
   autoRender: true,
-  exportButtonText: t.export,
+  exportButtonText: null,
   onExportButtonClick: null,
 };

--- a/packages/page-spy-plugin-ospy/src/index.ts
+++ b/packages/page-spy-plugin-ospy/src/index.ts
@@ -13,6 +13,7 @@ import { modal } from './utils/modal';
 import { ROOT_ID } from './utils/constant';
 import { Config, defaultConfig } from './config';
 import closeSvg from './assets/close.svg';
+import { i18n } from './utils/locale';
 
 class OSpy {
   $pageSpy: PageSpy | null = null;
@@ -43,6 +44,9 @@ class OSpy {
       ...defaultConfig,
       ...userCfg,
     };
+    if (this.config.lang) {
+      i18n.setLang(this.config.lang);
+    }
     this.init();
     this.render();
   }

--- a/packages/page-spy-plugin-ospy/src/utils/build-form.ts
+++ b/packages/page-spy-plugin-ospy/src/utils/build-form.ts
@@ -2,7 +2,7 @@ import type DataHarborPlugin from '@huolala-tech/page-spy-plugin-data-harbor';
 import type { PeriodItem } from '@huolala-tech/page-spy-plugin-data-harbor/dist/types/harbor/base';
 import classes from '../styles/index.module.less';
 import refreshSvg from '../assets/refresh.svg?raw';
-import { t } from './locale';
+import { i18n } from './locale';
 import { formatTime } from '.';
 import { Toast } from './toast';
 import { modal } from './modal';
@@ -29,7 +29,7 @@ export const buildForm = ({ harborPlugin, config }: Params) => {
         <div class="${classes.formItem}">
           <label>
             <span>
-              ${t.selectPeriod}: 
+              ${i18n.t('selectPeriod')}: 
             </span>
             <button class="${classes.refreshButton}" type="button">${refreshSvg}</button>
           </label>
@@ -45,9 +45,9 @@ export const buildForm = ({ harborPlugin, config }: Params) => {
         <!-- 表单项：备注信息 -->
         <div class="${classes.formItem}">
           <label>
-            <span>${t.remark}:</span>
+            <span>${i18n.t('remark')}:</span>
           </label>
-          <textarea name="description" rows="3" placeholder="${t.remarkPlaceholder}"></textarea>
+          <textarea name="description" rows="3" placeholder="${i18n.t('remarkPlaceholder')}"></textarea>
         </div>
       </div>
 
@@ -58,7 +58,7 @@ export const buildForm = ({ harborPlugin, config }: Params) => {
           <span class="${classes.duration}">--</span>
         </div>
         <button type="submit" data-primary>
-          ${config.exportButtonText || t.export}
+          ${config.exportButtonText || i18n.t('export')}
         </button>
       </div>
     </form>`,
@@ -148,7 +148,7 @@ export const buildForm = ({ harborPlugin, config }: Params) => {
   refreshButton.addEventListener('click', () => {
     refreshButton.disabled = true;
     refreshPeriods();
-    Toast.message(t.refreshed);
+    Toast.message(i18n.t('refreshed'));
     refreshButton.disabled = false;
   });
   minThumb.addEventListener('input', () => {
@@ -197,19 +197,19 @@ export const buildForm = ({ harborPlugin, config }: Params) => {
 
     try {
       submit.disabled = true;
-      submit.textContent = t.readying;
+      submit.textContent = i18n.t('readying');
       await harborPlugin!.onOfflineLog('download-periods', {
         ...getSelectedPeriod(),
         remark: `${description.value}`,
       });
 
-      Toast.show('success', t.success);
+      Toast.show('success', i18n.t('success'));
       modal.close();
     } catch (e: any) {
-      submit.textContent = t.fail;
+      submit.textContent = i18n.t('fail');
       Toast.show('error', e.message);
     } finally {
-      submit.textContent = t.export;
+      submit.textContent = i18n.t('export');
       submit.disabled = false;
     }
   });

--- a/packages/page-spy-plugin-ospy/src/utils/locale.ts
+++ b/packages/page-spy-plugin-ospy/src/utils/locale.ts
@@ -1,6 +1,6 @@
-import { isCN } from '@huolala-tech/page-spy-base';
+import { Translation } from '@huolala-tech/page-spy-base';
 
-const source = {
+const locales = {
   zh: {
     desc1: '操作录制基于 PageSpy 技术实现，',
     desc2: '查看文档',
@@ -42,4 +42,6 @@ const source = {
   },
 };
 
-export const t = isCN() ? source.zh : source.en;
+export const i18n = new Translation({
+  locales,
+});

--- a/packages/page-spy-plugin-ospy/src/utils/modal.ts
+++ b/packages/page-spy-plugin-ospy/src/utils/modal.ts
@@ -2,7 +2,7 @@ import { isString } from '@huolala-tech/page-spy-base';
 import type { ModalConfig, ShowParams } from '@huolala-tech/page-spy-types';
 import classes from '../styles/modal.module.less';
 import closeSvg from '../assets/close.svg';
-import { t } from './locale';
+import { i18n } from './locale';
 
 const defaultConfig: Omit<ModalConfig, 'footer'> = {
   logo: '',
@@ -14,31 +14,33 @@ const defaultConfig: Omit<ModalConfig, 'footer'> = {
 class Modal extends EventTarget {
   private config = defaultConfig;
 
-  private template = `
-  <div class="${classes.modal}">
-    <div class="${classes.content}">
-      <!-- Header -->
-      <div class="${classes.header}">
-        <div class="${classes.headerLeft}">
-          <img class="${classes.logo}" />
-          <div class="${classes.title}">
-            <b></b>
-            <p>
-              <span>${t.desc1}</span>
-              <a href="https://www.pagespy.org/#/o-spy" target="_blank">${t.desc2}</a>
-            </p>
+  private get template() {
+    return `
+      <div class="${classes.modal}">
+        <div class="${classes.content}">
+          <!-- Header -->
+          <div class="${classes.header}">
+            <div class="${classes.headerLeft}">
+              <img class="${classes.logo}" />
+              <div class="${classes.title}">
+                <b></b>
+                <p>
+                  <span>${i18n.t('desc1')}</span>
+                  <a href="https://www.pagespy.org/#/o-spy" target="_blank">${i18n.t('desc2')}</a>
+                </p>
+              </div>
+            </div>
+            <div class="${classes.headerRight}">
+              <img class="${classes.close}" src="${closeSvg}" />
+            </div>
           </div>
-        </div>
-        <div class="${classes.headerRight}">
-          <img class="${classes.close}" src="${closeSvg}" />
+
+          <!-- Main content -->
+          <div class="${classes.main}"></div>
         </div>
       </div>
-
-      <!-- Main content -->
-      <div class="${classes.main}"></div>
-    </div>
-  </div>
-  `;
+      `;
+  }
 
   public root: HTMLDivElement | null = null;
 


### PR DESCRIPTION
## Changes

之前，PageSpy 显示的语言是通过 navigator.languages 判断的，大致逻辑如下：

```ts
const isCN = () => {
  const langs = navigator.languages;
  return ['zh-CN', 'zh-HK', 'zh-TW', 'zh', 'zh-Hans-CN'].some((l) => {
    return langs.includes(l);
  });
}

if (isCN()) {
  // 显示中文
} else {
  // 显示英文
}
```

现在 PageSpy 支持直接或间接的方式配置显示的语言，下面配置按优先级顺序排列：
1. 实例化的时候手动指定:
    ```ts
    // PageSpy
    new PageSpy({
      lang: 'zh' | 'en'
    });
  
    // O-Spy
    new OSpy({
      lang: 'zh' | 'en'
    }) 
    ```
2. 从 `html` 标签上配置：
    ```html
    <html lang="en">...</html>
    ```
3. 从 `navigator.language` 读取用户浏览器首选语言，如果是下列之一，则显示中文、否则显示英文：
    ```ts
    ['zh-CN', 'zh-HK', 'zh-TW', 'zh', 'zh-Hans-CN']
    ```