### PR TITLE
feat(browser): add 'eventBus' property

### DIFF
--- a/packages/page-spy-browser/src/helpers/event-bus.ts
+++ b/packages/page-spy-browser/src/helpers/event-bus.ts
@@ -1,0 +1,1 @@
+export const eventBus = new EventTarget();

--- a/packages/page-spy-browser/src/helpers/modal.ts
+++ b/packages/page-spy-browser/src/helpers/modal.ts
@@ -2,6 +2,7 @@ import { isString, psLog } from '@huolala-tech/page-spy-base';
 import { ModalConfig, ShowParams } from '@huolala-tech/page-spy-types';
 import classes from '../assets/styles/modal.module.less';
 import closeSvg from '../assets/close.svg';
+import { eventBus } from './event-bus';
 
 const defaultConfig: ModalConfig = {
   logo: '',
@@ -23,10 +24,10 @@ export class modal {
   private static root: HTMLDivElement | null;
 
   private static template = `
-  <div class="${classes.modal}">
-    <div class="${classes.content}">
+  <div class="${classes.modal} page-spy-modal">
+    <div class="${classes.content} page-spy-modal-content">
       <!-- Header -->
-      <div class="${classes.header}">
+      <div class="${classes.header} page-spy-modal-header">
         <div class="${classes.headerLeft}">
           <img class="${classes.logo}" />
           <b class="${classes.title}"></b>
@@ -37,10 +38,10 @@ export class modal {
       </div>
 
       <!-- Main content -->
-      <div class="${classes.main}"></div>
+      <div class="${classes.main} page-spy-modal-main"></div>
 
       <!-- Footer -->
-      <div class="${classes.footer}"></div>
+      <div class="${classes.footer} page-spy-modal-footer"></div>
     </div>
   </div>
   `;
@@ -117,6 +118,7 @@ export class modal {
       mounted.appendChild(modal.root);
     }
     modal.root.classList.add('show');
+    eventBus.dispatchEvent(new Event('modal:show'));
   }
 
   public static close() {
@@ -126,6 +128,7 @@ export class modal {
     modal.root.classList.add('leaving');
     setTimeout(() => {
       modal.root?.classList.remove('leaving');
+      eventBus.dispatchEvent(new Event('modal:close'));
     }, 300);
   }
 

--- a/packages/page-spy-browser/src/index.ts
+++ b/packages/page-spy-browser/src/index.ts
@@ -38,6 +38,7 @@ import { modal } from './helpers/modal';
 import classes from './assets/styles/index.module.less';
 import { version } from '../package.json';
 import { i18n } from './assets/locales';
+import { eventBus } from './helpers/event-bus';
 
 type UpdateConfig = {
   title?: string;
@@ -113,6 +114,8 @@ class PageSpy {
 
   public cacheTimer: ReturnType<typeof setInterval> | null = null;
 
+  public eventBus = eventBus;
+
   constructor(ic: InitConfig = {}) {
     if (PageSpy.instance) {
       psLog.warn('Cannot initialize PageSpy multiple times');
@@ -163,6 +166,7 @@ class PageSpy {
       });
     }
     psLog.log('Plugins inited');
+    this.eventBus.dispatchEvent(new Event('core:inited'));
     if (config.autoRender) {
       this.render();
     }
@@ -332,7 +336,7 @@ class PageSpy {
       </div>
 
       <!-- Default content for modal -->
-      <div class="${classes.connectInfo}">
+      <div class="${classes.connectInfo} page-spy-connect-info">
         <p>
           <span>Device ID</span>
           <b style="font-family: 'Monaco'" class="page-spy-device-id">
@@ -430,6 +434,7 @@ class PageSpy {
     });
     this.handleDeviceDPR();
     psLog.log('Render success');
+    this.eventBus.dispatchEvent(new Event('core:rendered'));
   }
 
   private handleDeviceDPR() {
@@ -481,6 +486,7 @@ class PageSpy {
     if (root) {
       document.documentElement.removeChild(root);
     }
+    this.eventBus.dispatchEvent(new Event('core:aborted'));
   }
 }
 


### PR DESCRIPTION
## Related

https://github.com/HuolalaTech/page-spy-web/issues/340

## Changes

（浏览器端）PageSpy 新增 `eventBus` 实例属性，用于在 PageSpy 的几个关键交互节点对外抛出事件、便于用户参与控制。

使用方式如下：

```ts
window.$pageSpy = new PageSpy(...);

window.$pageSpy.eventBus.addEventListener("eventName", callback);
```

## 事件名及触发时机

- `core:inited`：PageSpy 已完成初始化，具体而言：配置、ws 连接已处理；
- `core:rendered`: PageSpy 的 DOM 节点已挂载到文档；
- `core:aborted`: 调用 `$pageSpy.abort()` 后回调；
- `modal:show`: 弹窗打开后回调；
- `modal:close`: 弹窗关闭后回调；