### PR TITLE
feat: browser & rn add WebSocketPlugin

### DIFF
--- a/packages/page-spy-base/src/network/common.ts
+++ b/packages/page-spy-base/src/network/common.ts
@@ -16,6 +16,12 @@ export const MAX_SIZE = 1024 * 1024 * 2;
 export const Reason = {
   EXCEED_SIZE: 'Exceed maximum limit',
 };
+export const PAGE_SPY_WS_ENDPOINT = '/api/v1/ws/room/join';
+export interface WebSocketMessage {
+  type: 'send' | 'receive';
+  data: any;
+  timestamp: number;
+}
 
 // Fork XMLHttpRequest status, for usage in platforms other than browser.
 export enum ReqReadyState {

--- a/packages/page-spy-browser/src/index.ts
+++ b/packages/page-spy-browser/src/index.ts
@@ -39,6 +39,8 @@ import classes from './assets/styles/index.module.less';
 import { version } from '../package.json';
 import { i18n } from './assets/locales';
 import { eventBus } from './helpers/event-bus';
+import EventSourcePlugin from './plugins/network/eventsource';
+import WebSocketPlugin from './plugins/network/websocket';
 
 type UpdateConfig = {
   title?: string;
@@ -498,6 +500,8 @@ const INTERNAL_PLUGINS = [
   new DatabasePlugin(),
   new PagePlugin(),
   new SystemPlugin(),
+  new EventSourcePlugin(),
+  new WebSocketPlugin(),
 ];
 
 INTERNAL_PLUGINS.forEach((p) => {

--- a/packages/page-spy-browser/src/plugins/network/eventsource.ts
+++ b/packages/page-spy-browser/src/plugins/network/eventsource.ts
@@ -23,6 +23,7 @@ export default class EventSourcePlugin
   extends WebNetworkProxyBase
   implements PageSpyPlugin
 {
+  // eslint-disable-next-line @typescript-eslint/brace-style
   public name = 'EventSourcePlugin';
 
   public static hasInitd = false;

--- a/packages/page-spy-browser/src/plugins/network/eventsource.ts
+++ b/packages/page-spy-browser/src/plugins/network/eventsource.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/brace-style */
 import {
   getRandomId,
   RequestItem,
@@ -23,7 +24,6 @@ export default class EventSourcePlugin
   extends WebNetworkProxyBase
   implements PageSpyPlugin
 {
-  // eslint-disable-next-line @typescript-eslint/brace-style
   public name = 'EventSourcePlugin';
 
   public static hasInitd = false;

--- a/packages/page-spy-browser/src/plugins/network/eventsource.ts
+++ b/packages/page-spy-browser/src/plugins/network/eventsource.ts
@@ -3,9 +3,11 @@ import {
   getRandomId,
   RequestItem,
   ReqReadyState,
+  NetworkProxyBase,
 } from '@huolala-tech/page-spy-base';
-import { PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import { OnInitParams, PageSpyPlugin } from '@huolala-tech/page-spy-types';
 import WebNetworkProxyBase from './proxy/base';
+import { InitConfig } from '../../config';
 
 const OriginEventSource = window.EventSource;
 
@@ -28,9 +30,10 @@ export default class EventSourcePlugin
 
   public static hasInitd = false;
 
-  public onInit() {
+  public onInit({ config }: OnInitParams<InitConfig>) {
     if (EventSourcePlugin.hasInitd) return;
     EventSourcePlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
 
     this.initProxyHandler();
   }

--- a/packages/page-spy-browser/src/plugins/network/eventsource.ts
+++ b/packages/page-spy-browser/src/plugins/network/eventsource.ts
@@ -3,7 +3,8 @@ import {
   RequestItem,
   ReqReadyState,
 } from '@huolala-tech/page-spy-base';
-import WebNetworkProxyBase from './base';
+import { PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import WebNetworkProxyBase from './proxy/base';
 
 const OriginEventSource = window.EventSource;
 
@@ -18,9 +19,18 @@ const OriginEventSource = window.EventSource;
  * does not dispatch the "message" event listener, and we can't get what the value
  * of the event actually is.
  */
-export default class SSEProxy extends WebNetworkProxyBase {
-  constructor() {
-    super();
+export default class EventSourcePlugin
+  extends WebNetworkProxyBase
+  implements PageSpyPlugin
+{
+  public name = 'EventSourcePlugin';
+
+  public static hasInitd = false;
+
+  public onInit() {
+    if (EventSourcePlugin.hasInitd) return;
+    EventSourcePlugin.hasInitd = true;
+
     this.initProxyHandler();
   }
 
@@ -91,7 +101,7 @@ export default class SSEProxy extends WebNetworkProxyBase {
     } as any;
   }
 
-  public reset() {
+  public onReset() {
     window.EventSource = OriginEventSource;
   }
 }

--- a/packages/page-spy-browser/src/plugins/network/index.ts
+++ b/packages/page-spy-browser/src/plugins/network/index.ts
@@ -4,7 +4,6 @@ import { NetworkProxyBase } from '@huolala-tech/page-spy-base';
 import XhrProxy from './proxy/xhr-proxy';
 import FetchProxy from './proxy/fetch-proxy';
 import BeaconProxy from './proxy/beacon-proxy';
-import SSEProxy from './proxy/sse-proxy';
 import { InitConfig } from '../../config';
 import { ResourceCollector } from './proxy/resource-collector';
 
@@ -16,8 +15,6 @@ export default class NetworkPlugin implements PageSpyPlugin {
   public fetchProxy: FetchProxy | null = null;
 
   public beaconProxy: BeaconProxy | null = null;
-
-  public sseProxy: SSEProxy | null = null;
 
   public resourceCollector: ResourceCollector | null = null;
 
@@ -31,7 +28,6 @@ export default class NetworkPlugin implements PageSpyPlugin {
     this.xhrProxy = new XhrProxy();
     this.fetchProxy = new FetchProxy();
     this.beaconProxy = new BeaconProxy();
-    this.sseProxy = new SSEProxy();
     this.resourceCollector = new ResourceCollector();
   }
 
@@ -39,7 +35,6 @@ export default class NetworkPlugin implements PageSpyPlugin {
     this.xhrProxy?.reset();
     this.fetchProxy?.reset();
     this.beaconProxy?.reset();
-    this.sseProxy?.reset();
     this.resourceCollector?.reset();
     NetworkPlugin.hasInitd = false;
   }

--- a/packages/page-spy-browser/src/plugins/network/websocket.ts
+++ b/packages/page-spy-browser/src/plugins/network/websocket.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/brace-style */
 import {
   getRandomId,
   RequestItem,
@@ -19,7 +20,6 @@ export default class WebSocketPlugin
   extends WebNetworkProxyBase
   implements PageSpyPlugin
 {
-  // eslint-disable-next-line @typescript-eslint/brace-style
   public name = 'WebSocketPlugin';
 
   public static hasInitd = false;

--- a/packages/page-spy-browser/src/plugins/network/websocket.ts
+++ b/packages/page-spy-browser/src/plugins/network/websocket.ts
@@ -4,19 +4,14 @@ import {
   RequestItem,
   ReqReadyState,
   NetworkProxyBase,
+  PAGE_SPY_WS_ENDPOINT,
+  WebSocketMessage,
 } from '@huolala-tech/page-spy-base';
 import { OnInitParams, PageSpyPlugin } from '@huolala-tech/page-spy-types';
 import WebNetworkProxyBase from './proxy/base';
 import { InitConfig } from '../../config';
 
 const OriginWebSocket = window.WebSocket;
-const PAGE_SPY_WS_ENDPOINT = '/api/v1/ws/room/join';
-
-interface WebSocketMessage {
-  type: 'send' | 'receive';
-  data: any;
-  timestamp: number;
-}
 
 export default class WebSocketPlugin
   extends WebNetworkProxyBase

--- a/packages/page-spy-browser/src/plugins/network/websocket.ts
+++ b/packages/page-spy-browser/src/plugins/network/websocket.ts
@@ -3,9 +3,11 @@ import {
   getRandomId,
   RequestItem,
   ReqReadyState,
+  NetworkProxyBase,
 } from '@huolala-tech/page-spy-base';
-import { PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import { OnInitParams, PageSpyPlugin } from '@huolala-tech/page-spy-types';
 import WebNetworkProxyBase from './proxy/base';
+import { InitConfig } from '../../config';
 
 const OriginWebSocket = window.WebSocket;
 const PAGE_SPY_WS_ENDPOINT = '/api/v1/ws/room/join';
@@ -24,9 +26,10 @@ export default class WebSocketPlugin
 
   public static hasInitd = false;
 
-  public onInit() {
+  public onInit({ config }: OnInitParams<InitConfig>) {
     if (WebSocketPlugin.hasInitd) return;
     WebSocketPlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
 
     this.initProxyHandler();
   }

--- a/packages/page-spy-browser/src/plugins/network/websocket.ts
+++ b/packages/page-spy-browser/src/plugins/network/websocket.ts
@@ -19,6 +19,7 @@ export default class WebSocketPlugin
   extends WebNetworkProxyBase
   implements PageSpyPlugin
 {
+  // eslint-disable-next-line @typescript-eslint/brace-style
   public name = 'WebSocketPlugin';
 
   public static hasInitd = false;

--- a/packages/page-spy-browser/src/plugins/network/websocket.ts
+++ b/packages/page-spy-browser/src/plugins/network/websocket.ts
@@ -1,0 +1,218 @@
+import {
+  getRandomId,
+  RequestItem,
+  ReqReadyState,
+} from '@huolala-tech/page-spy-base';
+import { PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import WebNetworkProxyBase from './proxy/base';
+
+const OriginWebSocket = window.WebSocket;
+const PAGE_SPY_WS_ENDPOINT = '/api/v1/ws/room/join';
+
+interface WebSocketMessage {
+  type: 'send' | 'receive';
+  data: any;
+  timestamp: number;
+}
+
+export default class WebSocketPlugin
+  extends WebNetworkProxyBase
+  implements PageSpyPlugin
+{
+  public name = 'WebSocketPlugin';
+
+  public static hasInitd = false;
+
+  public onInit() {
+    if (WebSocketPlugin.hasInitd) return;
+    WebSocketPlugin.hasInitd = true;
+
+    this.initProxyHandler();
+  }
+
+  public initProxyHandler() {
+    if (!window.WebSocket) {
+      return;
+    }
+
+    const _wsProxy = this;
+    window.WebSocket = class PageSpyWebSocketProxy {
+      private ws: WebSocket | null = null;
+
+      private requestId: string | null = null;
+
+      private req: RequestItem | null = null;
+
+      private id = 0;
+
+      constructor(url: string | URL, protocols?: string | string[]) {
+        const { pathname } = new URL(url, window.location.href);
+        if (pathname.startsWith(PAGE_SPY_WS_ENDPOINT)) {
+          // @ts-ignore
+          // eslint-disable-next-line no-constructor-return
+          return new OriginWebSocket(url, protocols);
+        }
+
+        this.requestId = getRandomId();
+        _wsProxy.createRequest(this.requestId);
+        this.req = _wsProxy.getRequest(this.requestId)!;
+
+        // 设置基本请求信息
+        this.req.url = new URL(url, window.location.href).toString();
+        this.req.method = 'GET';
+        this.req.requestType = 'websocket';
+        this.req.requestHeader = [
+          ['Upgrade', 'websocket'],
+          ['Connection', 'Upgrade'],
+          ['Sec-WebSocket-Version', '13'],
+        ];
+        if (protocols) {
+          const protocolsStr = Array.isArray(protocols)
+            ? protocols.join(', ')
+            : protocols;
+          this.req.requestHeader.push(['Sec-WebSocket-Protocol', protocolsStr]);
+        }
+        this.req.readyState = ReqReadyState.UNSENT;
+        this.req.startTime = Date.now();
+        this.req.response = null;
+
+        // 创建原生 WebSocket 实例
+        this.ws = new OriginWebSocket(url, protocols);
+        this.setupEventListeners();
+
+        // 返回代理对象
+        const proxy = new Proxy(this, {
+          get(target, prop) {
+            if (prop in target) {
+              return (target as any)[prop];
+            }
+            const value = (target.ws as any)[prop];
+            return typeof value === 'function' ? value.bind(target.ws) : value;
+          },
+          set(target, prop, value) {
+            if (prop in target) {
+              (target as any)[prop] = value;
+            } else {
+              (target.ws as any)[prop] = value;
+            }
+            return true;
+          },
+        });
+
+        // eslint-disable-next-line no-constructor-return
+        return proxy;
+      }
+
+      private setupEventListeners() {
+        if (!this.ws) {
+          return;
+        }
+
+        // 监听连接打开事件
+        this.ws.addEventListener('open', () => {
+          if (!this.req || !this.requestId) return;
+          this.req.readyState = ReqReadyState.OPENED;
+          this.req.status = 101; // Switching Protocols
+          this.req.statusText = 'Switching Protocols';
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+          this.req.responseHeader = [
+            ['Upgrade', 'websocket'],
+            ['Connection', 'Upgrade'],
+          ];
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+
+        // 监听消息接收事件
+        this.ws.addEventListener('message', (event) => {
+          if (!this.req || !this.requestId) return;
+
+          const message: WebSocketMessage = {
+            type: 'receive',
+            data: event.data,
+            timestamp: Date.now(),
+          };
+
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = 200;
+          this.req.statusText = 'OK';
+          this.req.response = message;
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+          this.req.lastEventId = String(this.id++);
+
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+
+        // 监听错误事件
+        this.ws.addEventListener('error', () => {
+          if (!this.req || !this.requestId) return;
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = 400;
+          this.req.statusText = 'WebSocket Error';
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+
+        // 监听连接关闭事件
+        this.ws.addEventListener('close', (event) => {
+          if (!this.req || !this.requestId) return;
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = event.code;
+          this.req.statusText = event.reason || 'Connection Closed';
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+      }
+
+      // 代理 send 方法
+      send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        if (this.req && this.requestId) {
+          const message: WebSocketMessage = {
+            type: 'send',
+            data: this.formatSendData(data),
+            timestamp: Date.now(),
+          };
+
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = 200;
+          this.req.statusText = 'OK';
+          this.req.response = message;
+          this.req.lastEventId = String(this.id++);
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        }
+        // 调用原生 send 方法
+        return this.ws?.send(data);
+      }
+
+      close(code?: number, reason?: string) {
+        return this.ws?.close(code, reason);
+      }
+
+      private formatSendData(
+        data: string | ArrayBufferLike | Blob | ArrayBufferView,
+      ): string {
+        if (typeof data === 'string') {
+          return data;
+        }
+        if (data instanceof Blob) {
+          return '[Blob data]';
+        }
+        if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+          return '[Binary data]';
+        }
+        return String(data);
+      }
+    } as any;
+  }
+
+  public onReset() {
+    window.WebSocket = OriginWebSocket;
+  }
+}

--- a/packages/page-spy-mp-base/src/index.ts
+++ b/packages/page-spy-mp-base/src/index.ts
@@ -35,6 +35,7 @@ import ErrorPlugin from './plugins/error';
 import NetworkPlugin from './plugins/network';
 import SystemPlugin from './plugins/system';
 import StoragePlugin from './plugins/storage';
+// import WebSocketPlugin from './plugins/network/websocket';
 
 import socketStore, { MPSocketWrapper } from './helpers/socket';
 import Request from './api';
@@ -375,6 +376,7 @@ const INTERNAL_PLUGINS = [
   new NetworkPlugin(),
   new StoragePlugin(),
   new SystemPlugin(),
+  // new WebSocketPlugin(),
 ];
 
 INTERNAL_PLUGINS.forEach((p) => {

--- a/packages/page-spy-mp-base/src/plugins/network/websocket.ts
+++ b/packages/page-spy-mp-base/src/plugins/network/websocket.ts
@@ -1,0 +1,250 @@
+/* eslint-disable @typescript-eslint/brace-style */
+import {
+  NetworkProxyBase,
+  WebSocketMessage,
+  PAGE_SPY_WS_ENDPOINT,
+  ReqReadyState,
+} from '@huolala-tech/page-spy-base';
+import { OnInitParams, PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import {
+  getRandomId,
+  psLog,
+  toStringTag,
+} from '@huolala-tech/page-spy-base/dist/utils';
+import MPNetworkProxyBase from './proxy/base';
+import { InitConfig } from '../../config';
+import { getOriginMPSDK } from '../../helpers/mp-api';
+import { MPNetworkAPI, MPSocket, SendSocketMessageOptions } from '../../types';
+
+const formatData = (data: string | ArrayBuffer) => {
+  if (typeof data === 'string') {
+    return data;
+  }
+  return toStringTag(data);
+};
+
+export default class WebSocketPlugin
+  extends MPNetworkProxyBase
+  implements PageSpyPlugin
+{
+  public name = 'WebSocketPlugin';
+
+  public static hasInitd = false;
+
+  // 保存原始的 connectSocket 方法
+  public originConnectSocket: MPNetworkAPI['connectSocket'] | null = null;
+
+  public onInit({ config }: OnInitParams<InitConfig>) {
+    if (WebSocketPlugin.hasInitd) return;
+    WebSocketPlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
+
+    this.initProxyHandler();
+  }
+
+  public initProxyHandler() {
+    const that = this;
+    const mp = getOriginMPSDK();
+    const originConnectSocket = mp.connectSocket;
+
+    if (!originConnectSocket) {
+      psLog.warn('"connectSocket" is not available');
+      return;
+    }
+
+    this.originConnectSocket = originConnectSocket;
+
+    Object.defineProperty(mp, 'connectSocket', {
+      value(params: Parameters<MPNetworkAPI['connectSocket']>[0]) {
+        const task = originConnectSocket(params);
+        if (params.url.includes(PAGE_SPY_WS_ENDPOINT)) {
+          return task;
+        }
+
+        const id = getRandomId();
+        that.createRequest(id);
+        const req = that.getRequest(id);
+
+        if (req) {
+          req.url = params.url;
+          req.method = 'GET';
+          req.requestType = 'websocket';
+          req.status = 0;
+          req.statusText = 'Connecting';
+          req.startTime = Date.now();
+          req.readyState = ReqReadyState.UNSENT;
+
+          // 处理请求头
+          if (params.header) {
+            req.requestHeader = Object.entries(params.header).map(([k, v]) => [
+              String(k),
+              String(v),
+            ]);
+          } else {
+            req.requestHeader = [];
+          }
+
+          that.sendRequestItem(id, req);
+
+          const socketTask = originConnectSocket(params);
+
+          // 如果是 Promise，需要等待解析
+          if (socketTask instanceof Promise) {
+            return socketTask.then((t) => {
+              return that.proxySocketTask(t, id);
+            });
+          }
+
+          // 代理 SocketTask
+          return that.proxySocketTask(socketTask, id);
+        }
+
+        psLog.warn('Failed to create WebSocket request object');
+        return task;
+      },
+      configurable: true,
+      writable: true,
+      enumerable: true,
+    });
+  }
+
+  private proxySocketTask(socketTask: MPSocket, requestId: string): MPSocket {
+    const that = this;
+    const req = this.getRequest(requestId);
+    if (!req) return socketTask;
+
+    const originalOnOpen = socketTask.onOpen.bind(socketTask);
+    const originalOnClose = socketTask.onClose.bind(socketTask);
+    const originalOnError = socketTask.onError.bind(socketTask);
+    const originalOnMessage = socketTask.onMessage.bind(socketTask);
+    const originalSend = socketTask.send.bind(socketTask);
+    const originalClose = socketTask.close.bind(socketTask);
+
+    socketTask.onOpen = function (handler) {
+      return originalOnOpen((res) => {
+        req.status = 101;
+        req.statusText = 'Connected';
+        req.readyState = ReqReadyState.OPENED;
+        req.endTime = Date.now();
+        req.costTime = req.endTime - (req.startTime || req.endTime);
+
+        // 处理响应头
+        if (res.header) {
+          req.responseHeader = Object.entries(res.header).map(([k, v]) => [
+            String(k),
+            String(v),
+          ]);
+        }
+
+        that.sendRequestItem(requestId, req);
+
+        // 调用用户的处理函数
+        if (handler) {
+          handler(res);
+        }
+      });
+    };
+
+    socketTask.onClose = function (handler) {
+      return originalOnClose((res) => {
+        req.status = res.code;
+        req.statusText = 'Closed';
+        req.readyState = ReqReadyState.DONE;
+        req.endTime = Date.now();
+        req.costTime = req.endTime - (req.startTime || req.endTime);
+
+        that.sendRequestItem(requestId, req);
+
+        if (handler) {
+          handler(res);
+        }
+      });
+    };
+
+    socketTask.onError = function (handler) {
+      return originalOnError((err) => {
+        req.status = 0;
+        req.statusText = 'Error';
+        req.readyState = ReqReadyState.DONE;
+        req.endTime = Date.now();
+        req.costTime = req.endTime - (req.startTime || req.endTime);
+
+        that.sendRequestItem(requestId, req);
+
+        // 调用用户的处理函数
+        if (handler) {
+          handler(err);
+        }
+      });
+    };
+
+    socketTask.onMessage = function (handler) {
+      return originalOnMessage(({ data }) => {
+        const message: WebSocketMessage = {
+          type: 'receive',
+          data: typeof data === 'string' ? data : '[object ArrayBuffer]',
+          timestamp: Date.now(),
+        };
+        req.response = message;
+
+        that.sendRequestItem(requestId, req);
+
+        if (handler) {
+          handler(message);
+        }
+      });
+    };
+
+    socketTask.send = function (params) {
+      const originalSuccess = params.success;
+
+      const wrappedParams: SendSocketMessageOptions = {
+        ...params,
+        success: (res) => {
+          // 只有真的发送成功了，才发给 PageSpy
+          const data = formatData(params.data);
+          const message: WebSocketMessage = {
+            type: 'send',
+            data,
+            timestamp: Date.now(),
+          };
+          req.response = message;
+          that.sendRequestItem(requestId, req);
+
+          if (originalSuccess) {
+            originalSuccess(res);
+          }
+        },
+      };
+
+      return originalSend(wrappedParams);
+    };
+
+    // 代理 close 方法
+    socketTask.close = function (params) {
+      // 更新关闭状态
+      req.status = params.code || 1000; // 正常关闭
+      req.statusText = 'Closing';
+      req.readyState = ReqReadyState.LOADING;
+
+      that.sendRequestItem(requestId, req);
+
+      return originalClose(params);
+    };
+
+    return socketTask;
+  }
+
+  public onReset() {
+    if (this.originConnectSocket) {
+      const mp = getOriginMPSDK();
+      Object.defineProperty(mp, 'connectSocket', {
+        value: this.originConnectSocket,
+        configurable: true,
+        writable: true,
+        enumerable: true,
+      });
+      this.originConnectSocket = null;
+    }
+  }
+}

--- a/packages/page-spy-mp-base/src/types.ts
+++ b/packages/page-spy-mp-base/src/types.ts
@@ -20,12 +20,26 @@ export type SocketOnCloseHandler = (res: {
   code: number;
   reason: string;
 }) => void;
-export type SocketOnErrorHandler = (msg: string) => void;
-export type SocketOnMessageHandler = (data: string | ArrayBuffer) => void;
+export type SocketOnErrorHandler = (err: { errMsg: string }) => void;
+export type SocketOnMessageHandler = (data: {
+  data: string | ArrayBuffer;
+}) => void;
+export type SocketFnOptions = {
+  success: (params: { errMsg: string; [key: string]: any }) => void;
+  fail: (err: { errMsg: string; [key: string]: any }) => void;
+  complete: (res?: { errMsg: string; [key: string]: any }) => void;
+};
+export type SendSocketMessageOptions = {
+  data: string | ArrayBuffer;
+} & Partial<SocketFnOptions>;
+export type CloseSocketOptions = {
+  code?: number;
+  reason?: string;
+} & Partial<SocketFnOptions>;
 
 export type MPSocket = {
-  send(data: object): void;
-  close(data: {}): void;
+  send(data: SendSocketMessageOptions): void;
+  close(data: CloseSocketOptions): void;
   onOpen(fun: SocketOnOpenHandler): void;
   onClose(fun: SocketOnCloseHandler): void;
   onError(fun: SocketOnErrorHandler): void;

--- a/packages/page-spy-react-native/src/index.ts
+++ b/packages/page-spy-react-native/src/index.ts
@@ -18,6 +18,7 @@ import ConsolePlugin from './plugins/console';
 import ErrorPlugin from './plugins/error';
 import NetworkPlugin from './plugins/network';
 import SystemPlugin from './plugins/system';
+import WebSocketPlugin from './plugins/network/websocket';
 
 import socketStore from './helpers/socket';
 import Request from './api';
@@ -211,6 +212,7 @@ const INTERNAL_PLUGINS = [
   new ErrorPlugin(),
   new NetworkPlugin(),
   new SystemPlugin(),
+  new WebSocketPlugin(),
 ];
 
 INTERNAL_PLUGINS.forEach((p) => {

--- a/packages/page-spy-react-native/src/plugins/network/websocket.ts
+++ b/packages/page-spy-react-native/src/plugins/network/websocket.ts
@@ -1,0 +1,217 @@
+/* eslint-disable @typescript-eslint/brace-style */
+import {
+  getRandomId,
+  RequestItem,
+  ReqReadyState,
+  NetworkProxyBase,
+  PAGE_SPY_WS_ENDPOINT,
+  WebSocketMessage,
+} from '@huolala-tech/page-spy-base';
+import { OnInitParams, PageSpyPlugin } from '@huolala-tech/page-spy-types';
+import WebNetworkProxyBase from './proxy/base';
+import { InitConfig } from '../../config';
+
+const OriginWebSocket = globalThis.WebSocket;
+
+export default class WebSocketPlugin
+  extends WebNetworkProxyBase
+  implements PageSpyPlugin
+{
+  public name = 'WebSocketPlugin';
+
+  public static hasInitd = false;
+
+  public onInit({ config }: OnInitParams<InitConfig>) {
+    if (WebSocketPlugin.hasInitd) return;
+    WebSocketPlugin.hasInitd = true;
+    NetworkProxyBase.dataProcessor = config.dataProcessor.network;
+
+    this.initProxyHandler();
+  }
+
+  public initProxyHandler() {
+    if (!globalThis.WebSocket) {
+      return;
+    }
+
+    const _wsProxy = this;
+    globalThis.WebSocket = class PageSpyWebSocketProxy {
+      private ws: WebSocket | null = null;
+
+      private requestId: string | null = null;
+
+      private req: RequestItem | null = null;
+
+      private id = 0;
+
+      constructor(url: string, protocols?: string | string[]) {
+        const { pathname } = new URL(url);
+        if (pathname.startsWith(PAGE_SPY_WS_ENDPOINT)) {
+          // @ts-ignore
+          // eslint-disable-next-line no-constructor-return
+          return new OriginWebSocket(url, protocols);
+        }
+
+        this.requestId = getRandomId();
+        _wsProxy.createRequest(this.requestId);
+        this.req = _wsProxy.getRequest(this.requestId)!;
+
+        // 设置基本请求信息
+        this.req.url = url.toString();
+        this.req.method = 'GET';
+        this.req.requestType = 'websocket';
+        this.req.requestHeader = [
+          ['Upgrade', 'websocket'],
+          ['Connection', 'Upgrade'],
+          ['Sec-WebSocket-Version', '13'],
+        ];
+        if (protocols) {
+          const protocolsStr = Array.isArray(protocols)
+            ? protocols.join(', ')
+            : protocols;
+          this.req.requestHeader.push(['Sec-WebSocket-Protocol', protocolsStr]);
+        }
+        this.req.readyState = ReqReadyState.UNSENT;
+        this.req.startTime = Date.now();
+        this.req.response = null;
+
+        // 创建原生 WebSocket 实例
+        this.ws = new OriginWebSocket(url, protocols);
+        this.setupEventListeners();
+
+        // 返回代理对象
+        const proxy = new Proxy(this, {
+          get(target, prop) {
+            if (prop in target) {
+              return (target as any)[prop];
+            }
+            const value = (target.ws as any)[prop];
+            return typeof value === 'function' ? value.bind(target.ws) : value;
+          },
+          set(target, prop, value) {
+            if (prop in target) {
+              (target as any)[prop] = value;
+            } else {
+              (target.ws as any)[prop] = value;
+            }
+            return true;
+          },
+        });
+
+        // eslint-disable-next-line no-constructor-return
+        return proxy;
+      }
+
+      private setupEventListeners() {
+        if (!this.ws) {
+          return;
+        }
+
+        // 监听连接打开事件
+        this.ws.addEventListener('open', () => {
+          if (!this.req || !this.requestId) return;
+          this.req.readyState = ReqReadyState.OPENED;
+          this.req.status = 101; // Switching Protocols
+          this.req.statusText = 'Switching Protocols';
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+          this.req.responseHeader = [
+            ['Upgrade', 'websocket'],
+            ['Connection', 'Upgrade'],
+          ];
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+
+        // 监听消息接收事件
+        this.ws.addEventListener('message', (event) => {
+          if (!this.req || !this.requestId) return;
+
+          const message: WebSocketMessage = {
+            type: 'receive',
+            data: event.data,
+            timestamp: Date.now(),
+          };
+
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = 200;
+          this.req.statusText = 'OK';
+          this.req.response = message;
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+          this.req.lastEventId = String(this.id++);
+
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+
+        // 监听错误事件
+        this.ws.addEventListener('error', () => {
+          if (!this.req || !this.requestId) return;
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = 400;
+          this.req.statusText = 'WebSocket Error';
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+
+        // 监听连接关闭事件
+        this.ws.addEventListener('close', (event) => {
+          if (!this.req || !this.requestId) return;
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = event.code;
+          this.req.statusText = event.reason || 'Connection Closed';
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        });
+      }
+
+      // 代理 send 方法
+      send(data: string | ArrayBufferLike | Blob | ArrayBufferView) {
+        if (this.req && this.requestId) {
+          const message: WebSocketMessage = {
+            type: 'send',
+            data: this.formatSendData(data),
+            timestamp: Date.now(),
+          };
+
+          this.req.readyState = ReqReadyState.DONE;
+          this.req.status = 200;
+          this.req.statusText = 'OK';
+          this.req.response = message;
+          this.req.lastEventId = String(this.id++);
+          this.req.endTime = Date.now();
+          this.req.costTime = this.req.endTime - this.req.startTime;
+          _wsProxy.sendRequestItem(this.requestId, this.req);
+        }
+        // 调用原生 send 方法
+        return this.ws?.send(data);
+      }
+
+      close(code?: number, reason?: string) {
+        return this.ws?.close(code, reason);
+      }
+
+      private formatSendData(
+        data: string | ArrayBufferLike | Blob | ArrayBufferView,
+      ): string {
+        if (typeof data === 'string') {
+          return data;
+        }
+        if (data instanceof Blob) {
+          return '[Blob data]';
+        }
+        if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+          return '[Binary data]';
+        }
+        return String(data);
+      }
+    } as any;
+  }
+
+  public onReset() {
+    globalThis.WebSocket = OriginWebSocket;
+  }
+}

--- a/packages/page-spy-types/lib/network.d.ts
+++ b/packages/page-spy-types/lib/network.d.ts
@@ -5,6 +5,7 @@ export type RequestType =
   | 'mp-request'
   | 'mp-upload'
   | 'eventsource'
+  | 'websocket'
   | PerformanceResourceTiming['initiatorType'];
 
 export type ResponseType =


### PR DESCRIPTION
## Related

- close https://github.com/HuolalaTech/page-spy-web/issues/318
- https://github.com/HuolalaTech/page-spy-web/pull/357

## Changes

- Add separate WebsocketPlugin for **_Browser and React Native_**;

## Usage

`WebSocketPlugin` is enabled by default, and after the upgrade, the websocket data will be there. 
<img width="1552" height="987" alt="截屏2025-07-17 11 44 46" src="https://github.com/user-attachments/assets/57d2108a-9383-40cd-8aaf-0dc110e1baa5" />

### Disable plugin

However, if you are not interested in its data, or if the large amount of data affects the user experience, you can disable the plugin to turn it off.

```diff
const $pageSpy = new PageSpy({
  ...,
+ disabledPlugins: ["WebSocketPlugin"]
}) 
```

## FAQ

### Q: Why not avaiable in Miniprogram?

Mini programs are limited to only one WebSocket connection (some platforms allow up to two). PageSpy occupies one of them, which means the WebSocket plugin is currently unavailable in mini programs. However, we’ve already prepared it and will make its capabilities available once it becomes usable in the future.